### PR TITLE
Feat: added sub notice feature api logic

### DIFF
--- a/feat_notices_sub_notice_type.md
+++ b/feat_notices_sub_notice_type.md
@@ -1,9 +1,6 @@
 ## Adding `notice_sub_type` to notices table
 
-A migration has been added to include the `notice_sub_type` column in the `notices` table. The `create` API now supports this new field and performs validation.
-
-**Migration:**  
-Run the following SQL to update your notices schema:
+A new column `notice_sub_type` has been added to the `notices` table to support sub-types for certain notice types. The following SQL migration is required:
 
 ```sql
 ALTER TABLE notices ADD COLUMN notice_sub_type VARCHAR(255) NULL;
@@ -13,11 +10,69 @@ ALTER TABLE notices ADD COLUMN notice_sub_type VARCHAR(255) NULL;
 
 ## API Changes
 
-### 1. `/api/create` (POST)
+Three endpoints now fully support `notice_sub_type` with validation:
+
+---
+
+### 1. `/api/notice` (GET)
 
 #### Description
 
-Supports creation of notices with an additional, validated `notice_sub_type` field. If the given `notice_type` requires a sub-type, the request must include a valid `notice_sub_type`. Error handling is included for missing or invalid sub-types.
+You can now filter notices by both `type` and `notice_sub_type` (both are case-insensitive and trimmed). If both parameters are provided, only notices matching **both** the type and sub-type will be returned.
+
+#### Example: Valid Request
+
+```
+GET http://localhost:3000/api/notice?type=JOb&notice_sub_type=rEGULARTEACHING
+```
+
+#### Example: Successful Response (`200 OK`)
+
+```json
+[
+  {
+    "id": "12345",
+    "title": "Holiday Announcement",
+    "timestamp": "1775655248700",
+    "openDate": "1717200000000",
+    "closeDate": "1717545600000",
+    "important": 1,
+    "isVisible": 1,
+    "attachments": [
+      {
+        "name": "HolidayList.pdf",
+        "url": "https://example.com/HolidayList.pdf"
+      }
+    ],
+    "email": "admin@nitp.ac.in",
+    "isDept": 0,
+    "notice_link": "https://example.com/notices/holiday",
+    "notice_type": "JOB",
+    "updatedBy": "shivamg.ug24.cs@nitp.ac.in",
+    "updatedAt": "1775655248700",
+    "department": "CSE",
+    "notice_sub_type": "REGULARTEACHING"
+  }
+]
+```
+
+- If results are found, an array of notices is returned (`200 OK`) as above.
+- Notice that both `type` and `notice_sub_type` accept any casing but are normalized to UPPERCASE in responses.
+- If the `type` is invalid, you get:
+
+```json
+{
+  "message": "Invalid type parameter"
+}
+```
+
+---
+
+### 2. `/api/create` (POST)
+
+#### Description
+
+Allows creation of notices with the optional `notice_sub_type` field. If a given `notice_type` requires a sub-type, a valid `notice_sub_type` **must** be provided or the API responds with an error.
 
 #### Example: Valid Request Payload
 
@@ -53,8 +108,6 @@ Supports creation of notices with an additional, validated `notice_sub_type` fie
 }
 ```
 
----
-
 #### Example: Invalid Request Payload (Missing Required `notice_sub_type`)
 
 ```json
@@ -77,9 +130,7 @@ Supports creation of notices with an additional, validated `notice_sub_type` fie
   "email": "admin@institute.ac.in"
 }
 ```
-
-#### Example: Error API Response
-
+Returns:
 ```json
 {
   "message": "Invalid or missing notice_sub_type for notice_type: job"
@@ -88,11 +139,11 @@ Supports creation of notices with an additional, validated `notice_sub_type` fie
 
 ---
 
-### 2. `/api/update` (PUT)
+### 3. `/api/update` (PUT)
 
 #### Description
 
-Supports updating notices with the `notice_sub_type` field. Updates are performed at the notice level with full authorization checks. The API validates that if the given `notice_type` requires a sub-type, a valid `notice_sub_type` must be included.
+Allows updating notices including the `notice_sub_type` field. If the updated notice’s `notice_type` requires a sub-type, a valid `notice_sub_type` **must** be included in the payload, else the update will fail.
 
 #### Example: Valid Request Payload
 
@@ -111,7 +162,7 @@ Supports updating notices with the `notice_sub_type` field. Updates are performe
       {
         "name": "job_description.pdf",
         "url": "https://docs.cloud.google.com/faculty-job-posting-2024.pdf"
-      },
+      }
     ],
     "important": 1,
     "department": "AR",
@@ -136,8 +187,6 @@ Supports updating notices with the `notice_sub_type` field. Updates are performe
 }
 ```
 
----
-
 #### Example: Invalid Request Payload (Missing Required `notice_sub_type`)
 
 ```json
@@ -154,9 +203,7 @@ Supports updating notices with the `notice_sub_type` field. Updates are performe
   "type": "notice"
 }
 ```
-
-#### Example: Error API Response
-
+Returns:
 ```json
 {
   "message": "Invalid or missing notice_sub_type for notice_type: job"
@@ -167,13 +214,11 @@ Supports updating notices with the `notice_sub_type` field. Updates are performe
 
 #### Authorization Notes
 
-- **SUPER_ADMIN**: Can update any notice
-- **ACADEMIC_ADMIN**: Can only update notices with `notice_type` = `'academics'`
-- **DEPT_ADMIN**: Can only update notices with `notice_type` = `'department'` matching their department
-
-The update automatically sets `updatedAt` to the current timestamp.
+- **SUPER_ADMIN:** Can update any notice.
+- **ACADEMIC_ADMIN:** Can only update notices with `notice_type = 'academics'`.
+- **DEPT_ADMIN:** Can only update notices with `notice_type = 'department'` and matching their own department.
+- All updates set `updatedAt` to the current timestamp automatically.
 
 ---
 
-Just ensure your request payload includes a valid `notice_sub_type` string whenever it is required by the `notice_type` you are submitting or updating.  
-The examples above show both success and error responses for reference.
+> Ensure all payloads provide a valid `notice_sub_type` string whenever required by the `notice_type`. See examples above for both success and error outputs.

--- a/feat_notices_sub_notice_type.md
+++ b/feat_notices_sub_notice_type.md
@@ -4,6 +4,7 @@ A migration has been added to include the `notice_sub_type` column in the `notic
 
 **Migration:**  
 Run the following SQL to update your notices schema:
+
 ```sql
 ALTER TABLE notices ADD COLUMN notice_sub_type VARCHAR(255) NULL;
 ```
@@ -15,9 +16,11 @@ ALTER TABLE notices ADD COLUMN notice_sub_type VARCHAR(255) NULL;
 ### 1. `/api/create` (POST)
 
 #### Description
+
 Supports creation of notices with an additional, validated `notice_sub_type` field. If the given `notice_type` requires a sub-type, the request must include a valid `notice_sub_type`. Error handling is included for missing or invalid sub-types.
 
 #### Example: Valid Request Payload
+
 ```json
 {
   "id": "1702472618475",
@@ -41,6 +44,7 @@ Supports creation of notices with an additional, validated `notice_sub_type` fie
 ```
 
 #### Example: Successful API Response
+
 ```json
 {
   "affectedRows": 1,
@@ -52,6 +56,7 @@ Supports creation of notices with an additional, validated `notice_sub_type` fie
 ---
 
 #### Example: Invalid Request Payload (Missing Required `notice_sub_type`)
+
 ```json
 {
   "id": "1702472618476",
@@ -74,6 +79,7 @@ Supports creation of notices with an additional, validated `notice_sub_type` fie
 ```
 
 #### Example: Error API Response
+
 ```json
 {
   "message": "Invalid or missing notice_sub_type for notice_type: job"
@@ -82,7 +88,92 @@ Supports creation of notices with an additional, validated `notice_sub_type` fie
 
 ---
 
-*(Further API changes and examples should be added to this section similarly, grouped by endpoint and method.)*
+### 2. `/api/update` (PUT)
 
-Just ensure your request payload includes a valid `notice_sub_type` string whenever it is required by the `notice_type` you are submitting.  
+#### Description
+
+Supports updating notices with the `notice_sub_type` field. Updates are performed at the notice level with full authorization checks. The API validates that if the given `notice_type` requires a sub-type, a valid `notice_sub_type` must be included.
+
+#### Example: Valid Request Payload
+
+```json
+{
+  "data": {
+    "id": 1775663250583,
+    "title": "Regular Teaching Faculty Position - Computer Science Department",
+    "email": "mps@nitp.ac.in",
+    "openDate": 1712534400000,
+    "closeDate": 1715212800000,
+    "notice_type": "job",
+    "notice_sub_type": "regularteaching",
+    "category": "FACULTY",
+    "attachments": [
+      {
+        "name": "job_description.pdf",
+        "url": "https://docs.cloud.google.com/faculty-job-posting-2024.pdf"
+      },
+    ],
+    "important": 1,
+    "department": "AR",
+    "isDept": 0,
+    "isVisible": 1
+  },
+  "type": "notice"
+}
+```
+
+#### Example: Successful API Response
+
+```json
+{
+  "fieldCount": 0,
+  "affectedRows": 1,
+  "insertId": 0,
+  "info": "Rows matched: 1  Changed: 1  Warnings: 0",
+  "serverStatus": 2,
+  "warningStatus": 0,
+  "changedRows": 1
+}
+```
+
+---
+
+#### Example: Invalid Request Payload (Missing Required `notice_sub_type`)
+
+```json
+{
+  "data": {
+    "id": 1775663250583,
+    "title": "Updated Notice Missing Sub Type",
+    "notice_type": "job",
+    "openDate": 1775606400000,
+    "closeDate": 1775606400000,
+    "department": "AR",
+    "isDept": 0
+  },
+  "type": "notice"
+}
+```
+
+#### Example: Error API Response
+
+```json
+{
+  "message": "Invalid or missing notice_sub_type for notice_type: job"
+}
+```
+
+---
+
+#### Authorization Notes
+
+- **SUPER_ADMIN**: Can update any notice
+- **ACADEMIC_ADMIN**: Can only update notices with `notice_type` = `'academics'`
+- **DEPT_ADMIN**: Can only update notices with `notice_type` = `'department'` matching their department
+
+The update automatically sets `updatedAt` to the current timestamp.
+
+---
+
+Just ensure your request payload includes a valid `notice_sub_type` string whenever it is required by the `notice_type` you are submitting or updating.  
 The examples above show both success and error responses for reference.

--- a/feat_notices_sub_notice_type.md
+++ b/feat_notices_sub_notice_type.md
@@ -1,0 +1,88 @@
+## Adding `notice_sub_type` to notices table
+
+A migration has been added to include the `notice_sub_type` column in the `notices` table. The `create` API now supports this new field and performs validation.
+
+**Migration:**  
+Run the following SQL to update your notices schema:
+```sql
+ALTER TABLE notices ADD COLUMN notice_sub_type VARCHAR(255) NULL;
+```
+
+---
+
+## API Changes
+
+### 1. `/api/create` (POST)
+
+#### Description
+Supports creation of notices with an additional, validated `notice_sub_type` field. If the given `notice_type` requires a sub-type, the request must include a valid `notice_sub_type`. Error handling is included for missing or invalid sub-types.
+
+#### Example: Valid Request Payload
+```json
+{
+  "id": "1702472618475",
+  "title": "Test with sub type",
+  "notice_type": "job",
+  "notice_sub_type": "regularteaching",
+  "openDate": 1702472618000,
+  "closeDate": 1702472618000,
+  "department": "AR",
+  "attachments": [
+    {
+      "name": "test.doc",
+      "url": "https://docs.cloud.testman.pdf"
+    }
+  ],
+  "isDept": 0,
+  "important": 0,
+  "isVisible": 1,
+  "email": "admin@institute.ac.in"
+}
+```
+
+#### Example: Successful API Response
+```json
+{
+  "affectedRows": 1,
+  "insertId": "1702472618475",
+  "warningStatus": 0
+}
+```
+
+---
+
+#### Example: Invalid Request Payload (Missing Required `notice_sub_type`)
+```json
+{
+  "id": "1702472618476",
+  "title": "Test missing sub type",
+  "notice_type": "job",
+  "openDate": 1702472618000,
+  "closeDate": 1702472618000,
+  "department": "AR",
+  "attachments": [
+    {
+      "name": "test.doc",
+      "url": "https://docs.cloud.testman.pdf"
+    }
+  ],
+  "isDept": 0,
+  "important": 0,
+  "isVisible": 1,
+  "email": "admin@institute.ac.in"
+}
+```
+
+#### Example: Error API Response
+```json
+{
+  "message": "Invalid or missing notice_sub_type for notice_type: job"
+}
+```
+
+---
+
+*(Further API changes and examples should be added to this section similarly, grouped by endpoint and method.)*
+
+Just ensure your request payload includes a valid `notice_sub_type` string whenever it is required by the `notice_type` you are submitting.  
+The examples above show both success and error responses for reference.

--- a/feat_notices_sub_notice_type.md
+++ b/feat_notices_sub_notice_type.md
@@ -60,6 +60,8 @@ GET http://localhost:3000/api/notice?type=JOb&notice_sub_type=rEGULARTEACHING
 - Notice that both `type` and `notice_sub_type` accept any casing but are normalized to UPPERCASE in responses.
 - If the `type` is invalid, you get:
 
+#### Example: Error Response for Invalid Type (`400 Bad Request`)
+
 ```json
 {
   "message": "Invalid type parameter"
@@ -157,7 +159,6 @@ Allows updating notices including the `notice_sub_type` field. If the updated no
     "closeDate": 1715212800000,
     "notice_type": "job",
     "notice_sub_type": "regularteaching",
-    "category": "FACULTY",
     "attachments": [
       {
         "name": "job_description.pdf",
@@ -214,10 +215,14 @@ Returns:
 
 #### Authorization Notes
 
+**Authorization for `/api/update` only:**
+
 - **SUPER_ADMIN:** Can update any notice.
-- **ACADEMIC_ADMIN:** Can only update notices with `notice_type = 'academics'`.
-- **DEPT_ADMIN:** Can only update notices with `notice_type = 'department'` and matching their own department.
-- All updates set `updatedAt` to the current timestamp automatically.
+- **ACADEMIC_ADMIN:** Can update notices only if `notice_type = 'academics'`.
+- **DEPT_ADMIN:** Can update notices only if `notice_type = 'department'` and the `department` matches their own.
+- All updates automatically set `updatedAt` to the current timestamp.
+
+*Note: These authorization rules apply solely to the `/api/update` endpoint. Other endpoints such as `/api/create` (for creation).*
 
 ---
 

--- a/src/app/api/create/route.js
+++ b/src/app/api/create/route.js
@@ -4,6 +4,7 @@ import { query } from '@/lib/db'
 import { ROLES, hasAccess } from '@/lib/roles'
 // import { authOptions } from '../auth/[...nextauth]/route'
 import { authOptions } from '@/lib/authOptions'
+import { notice_sub_types } from '../../../lib/const';
 
 export async function POST(request) {
   const session = await getServerSession(authOptions)
@@ -17,8 +18,7 @@ export async function POST(request) {
 
   try {
     const { type, ...params } = await request.json()
-    // console.log(session.user.role,'dkfas;k')
-    // Notice handling based on role
+    
     if (type === 'notice') {
       console.log('DEBUG: Authorization check for notice creation')
       console.log('User role:', session.user.role)
@@ -40,11 +40,28 @@ export async function POST(request) {
         )
       }
 
+      if (params.data.notice_type) {
+        const noticeTypeKey = params.data.notice_type.toUpperCase();
+        if (notice_sub_types.hasOwnProperty(noticeTypeKey)) {
+          if (
+            !params.data.notice_sub_type ||
+            !notice_sub_types[noticeTypeKey].some(
+              ([subKey]) => subKey === params.data.notice_sub_type
+            )
+          ) {
+            return NextResponse.json(
+              { message: "Invalid or missing notice_sub_type for notice_type: " + params.data.notice_type },
+              { status: 400 }
+            );
+          }
+        }
+      }
+
       const noticeResult = await query(
         `INSERT INTO notices(
     id, title, timestamp, openDate, closeDate, important, isVisible, attachments, email, 
-    isDept, notice_link, notice_type, updatedBy, updatedAt, department
-  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    isDept, notice_link, notice_type, updatedBy, updatedAt, department,notice_sub_type
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,?)`,
   [
     params.data.id,
     params.data.title,
@@ -61,6 +78,7 @@ export async function POST(request) {
     session.user.email,
     new Date().getTime(),
     params.data.department || null,
+    params.data.notice_sub_type?.toUpperCase()||null
   ]
       )
       return NextResponse.json(noticeResult)

--- a/src/app/api/create/route.js
+++ b/src/app/api/create/route.js
@@ -4,7 +4,7 @@ import { query } from '@/lib/db'
 import { ROLES, hasAccess } from '@/lib/roles'
 // import { authOptions } from '../auth/[...nextauth]/route'
 import { authOptions } from '@/lib/authOptions'
-import { notice_sub_types } from '../../../lib/const';
+import { notice_sub_types } from '@/lib/const';
 
 export async function POST(request) {
   const session = await getServerSession(authOptions)
@@ -40,18 +40,21 @@ export async function POST(request) {
         )
       }
 
-      if (params.data.notice_type) {
+      if (params.data.notice_type ) {
         const noticeTypeKey = params.data.notice_type.toUpperCase();
         if (notice_sub_types.hasOwnProperty(noticeTypeKey)) {
           if (
             !params.data.notice_sub_type ||
             !notice_sub_types[noticeTypeKey].some(
-              ([subKey]) => subKey === params.data.notice_sub_type
-            )
-          ) {
+            ([_,upKey]) => upKey===params.data.notice_sub_type,
+            )          ) {
             return NextResponse.json(
-              { message: "Invalid or missing notice_sub_type for notice_type: " + params.data.notice_type },
-              { status: 400 }
+              {
+                message:
+                  "Invalid or missing notice_sub_type for notice_type: " +
+                  params.data.notice_type,
+              },
+              { status: 400 },
             );
           }
         }
@@ -75,10 +78,9 @@ export async function POST(request) {
     params.data.isDept || 0,
     params.data.notice_link || null,
     params.data.notice_type || null,
-    session.user.email,
-    new Date().getTime(),
+    session.user.email,    new Date().getTime(),
     params.data.department || null,
-    params.data.notice_sub_type?.toUpperCase()||null
+    params.data.notice_sub_type?.trim()?.toUpperCase()||null
   ]
       )
       return NextResponse.json(noticeResult)

--- a/src/app/api/notice/route.js
+++ b/src/app/api/notice/route.js
@@ -1,64 +1,94 @@
-import { NextResponse } from 'next/server'
-import { query } from '@/lib/db'
-import { administrationList, depList } from '@/lib/const'
+import { NextResponse } from "next/server";
+import { query } from "@/lib/db";
+import { administrationList, depList } from "@/lib/const";
 
 export async function GET(request) {
   try {
-    const { searchParams } = new URL(request.url)
-    const type = searchParams.get('type')
-    const now = new Date().getTime()
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get("type");
+    const subNoticeType = searchParams.get("notice-sub_types"); // add sub_notice_types
+    const now = new Date().getTime();
 
-    let results
+    let results;
     switch (type) {
-      case 'all':
-        results = await query(
-          `SELECT * FROM notices 
-           ORDER BY timestamp DESC`
-        )
-        break
+      case "all":
+        if (subNoticeType) {
+          results = await query(
+            `SELECT * FROM notices 
+             WHERE sub_notice_type = ?
+             ORDER BY timestamp DESC`,
+            [subNoticeType],
+          );
+        } else {
+          results = await query(
+            `SELECT * FROM notices 
+             ORDER BY timestamp DESC`,
+          );
+        }
+        break;
 
       case "tender":
-        results=await query(
-          `SELECT * FROM notices 
-          where notice_type="tender"
-           ORDER BY timestamp DESC`
-        )
-        break
+        if (subNoticeType) {
+          results = await query(
+            `SELECT * FROM notices 
+             WHERE notice_type="tender" 
+             AND sub_notice_type = ?
+             ORDER BY timestamp DESC`,
+            [subNoticeType],
+          );
+        } else {
+          results = await query(
+            `SELECT * FROM notices 
+             WHERE notice_type="tender"
+             ORDER BY timestamp DESC`,
+          );
+        }
+        break;
 
-      case 'whole':
+      case "whole":
         results = await query(
           `SELECT * FROM notices 
-           ORDER BY openDate DESC`
-        )
-        break
+           ORDER BY openDate DESC`,
+        );
+        break;
 
-      case 'active':
+      case "active":
         results = await query(
           `SELECT * FROM notices 
            WHERE notice_type = 'general' 
            AND openDate < ? AND closeDate > ? 
            ORDER BY openDate DESC`,
-          [now, now]
-        )
-        break
+          [now, now],
+        );
+        break;
 
-      case 'academics':
+      case "academics":
         results = await query(
           `SELECT * FROM notices 
            WHERE notice_type = 'academics'
-           ORDER BY timestamp DESC`
-        )
-        break
+           ORDER BY timestamp DESC`,
+        );
+        break;
 
       default:
-        // Check if it's an administration notice type
+
         if (administrationList.has(type)) {
-          results = await query(
-            `SELECT * FROM notices 
-             WHERE notice_type = ? 
-             ORDER BY timestamp DESC`,
-            [type]
-          )
+          if (subNoticeType) {
+            results = await query(
+              `SELECT * FROM notices 
+               WHERE notice_type = ? 
+               AND sub_notice_type = ?
+               ORDER BY timestamp DESC`,
+              [type, subNoticeType],
+            );
+          } else {
+            results = await query(
+              `SELECT * FROM notices 
+               WHERE notice_type = ? 
+               ORDER BY timestamp DESC`,
+              [type],
+            );
+          }
         }
         // Check if it's a department notice
         else if (depList.has(type)) {
@@ -67,40 +97,36 @@ export async function GET(request) {
              WHERE notice_type = 'department' 
              AND department = ? 
              ORDER BY timestamp DESC`,
-            [depList.get(type)]
-          )
-        }
-        else {
+            [depList.get(type)],
+          );
+        } else {
           return NextResponse.json(
-            { message: 'Invalid type parameter' },
-            { status: 400 }
-          )
+            { message: "Invalid type parameter" },
+            { status: 400 },
+          );
         }
     }
 
     // Parse attachments JSON for each result
-    const notices = JSON.parse(JSON.stringify(results))
-    notices.forEach(notice => {
+    const notices = JSON.parse(JSON.stringify(results));
+    notices.forEach((notice) => {
       if (notice.attachments) {
-        notice.attachments = JSON.parse(notice.attachments)
+        notice.attachments = JSON.parse(notice.attachments);
       }
-    })
+    });
 
-    return NextResponse.json(notices)
-
+    return NextResponse.json(notices);
   } catch (error) {
-    console.error('API Error:', error)
-    return NextResponse.json(
-      { message: error.message },
-      { status: 500 }
-    )
+    console.error("API Error:", error);
+    return NextResponse.json({ message: error.message }, { status: 500 });
   }
 }
 
 export async function POST(request) {
+    
   try {
-    const body = await request.json()
-    let { 
+    const body = await request.json();
+    let {
       type,
       start_date,
       end_date,
@@ -108,61 +134,65 @@ export async function POST(request) {
       notice_type,
       from,
       to,
-      keyword = '',
-    } = body
-    
+      keyword = "",
+    } = body;
+
     // Ensure from and to are valid integers
-    from = parseInt(from) || 0
-    to = parseInt(to) || 15
-    
+    from = parseInt(from) || 0;
+    to = parseInt(to) || 15;
+
     // Validate that from and to are valid
-    if (from < 0) from = 0
-    if (to <= from) to = from + 15
-    
-    let results
+    if (from < 0) from = 0;
+    if (to <= from) to = from + 15;
+
+    let results;
 
     // For ACADEMIC_ADMIN, always filter for academic notices
-    if (notice_type === 'academics') {
-      const limit = Math.max(1, Math.min(100, to - from))
-      const offset = Math.max(0, from)
-      console.log('DEBUG: Academic pagination params:', { offset, limit })
-      
+    if (notice_type === "academics") {
+      const limit = Math.max(1, Math.min(100, to - from));
+      const offset = Math.max(0, from);
+      console.log("DEBUG: Academic pagination params:", { offset, limit });
+
       results = await query(
         `SELECT * FROM notices 
          WHERE notice_type = ?
          ORDER BY openDate DESC 
          LIMIT ${limit} OFFSET ${offset}`,
-        ['academics']
-      )
-    } 
+        ["academics"],
+      );
+    }
     // For DEPT_ADMIN, filter for department notices of their department
-    else if (notice_type === 'department' && department) {
-      const limit = Math.max(1, Math.min(100, to - from))
-      const offset = Math.max(0, from)
-      console.log('DEBUG: Department pagination params:', { offset, limit, department })
-      
+    else if (notice_type === "department" && department) {
+      const limit = Math.max(1, Math.min(100, to - from));
+      const offset = Math.max(0, from);
+      console.log("DEBUG: Department pagination params:", {
+        offset,
+        limit,
+        department,
+      });
+
       results = await query(
         `SELECT * FROM notices 
          WHERE notice_type = ? AND department = ?
          ORDER BY openDate DESC 
          LIMIT ${limit} OFFSET ${offset}`,
-        ['department', department]
-      )
+        ["department", department],
+      );
     } else {
       switch (type) {
-        case 'range':
-          const rangeLimit = Math.max(1, Math.min(100, to - from))
-          const rangeOffset = Math.max(0, from)
-          
+        case "range":
+          const rangeLimit = Math.max(1, Math.min(100, to - from));
+          const rangeOffset = Math.max(0, from);
+
           if (!notice_type) {
             results = await query(
               `SELECT * FROM notices 
                WHERE title LIKE ? 
                ORDER BY openDate DESC 
                LIMIT ${rangeLimit} OFFSET ${rangeOffset}`,
-              [`%${keyword}%`]
-            )
-          } else if (notice_type !== 'department') {
+              [`%${keyword}%`],
+            );
+          } else if (notice_type !== "department") {
             results = await query(
               `SELECT * FROM notices 
                WHERE notice_type = ? 
@@ -171,8 +201,8 @@ export async function POST(request) {
                AND title LIKE ? 
                ORDER BY openDate DESC 
                LIMIT ${rangeLimit} OFFSET ${rangeOffset}`,
-              [notice_type, end_date, start_date, `%${keyword}%`]
-            )
+              [notice_type, end_date, start_date, `%${keyword}%`],
+            );
           } else {
             results = await query(
               `SELECT * FROM notices 
@@ -182,47 +212,48 @@ export async function POST(request) {
                AND title LIKE ? 
                ORDER BY openDate DESC 
                LIMIT ${rangeLimit} OFFSET ${rangeOffset}`,
-              [end_date, start_date, department, `%${keyword}%`]
-            )
+              [end_date, start_date, department, `%${keyword}%`],
+            );
           }
-          break
+          break;
 
-        case 'between':
-          const limit = Math.max(1, Math.min(100, to - from)) // Ensure limit is between 1 and 100
-          const offset = Math.max(0, from) // Ensure offset is non-negative
-          console.log('DEBUG: Pagination params:', { offset, limit, originalFrom: from, originalTo: to })
-          
+        case "between":
+          const limit = Math.max(1, Math.min(100, to - from)); // Ensure limit is between 1 and 100
+          const offset = Math.max(0, from); // Ensure offset is non-negative
+          console.log("DEBUG: Pagination params:", {
+            offset,
+            limit,
+            originalFrom: from,
+            originalTo: to,
+          });
+
           // Try without prepared statements for LIMIT clause
           results = await query(
             `SELECT * FROM notices 
              ORDER BY openDate DESC 
-             LIMIT ${limit} OFFSET ${offset}`
-          )
-          break
+             LIMIT ${limit} OFFSET ${offset}`,
+          );
+          break;
 
         default:
           return NextResponse.json(
-            { message: 'Invalid type parameter' },
-            { status: 400 }
-          )
+            { message: "Invalid type parameter" },
+            { status: 400 },
+          );
       }
     }
 
     // Parse attachments JSON for each result
-    const notices = JSON.parse(JSON.stringify(results))
-    notices.forEach(notice => {
+    const notices = JSON.parse(JSON.stringify(results));
+    notices.forEach((notice) => {
       if (notice.attachments) {
-        notice.attachments = JSON.parse(notice.attachments)
+        notice.attachments = JSON.parse(notice.attachments);
       }
-    })
+    });
 
-    return NextResponse.json(notices)
-
+    return NextResponse.json(notices);
   } catch (error) {
-    console.error('API Error:', error)
-    return NextResponse.json(
-      { message: error.message },
-      { status: 500 }
-    )
+    console.error("API Error:", error);
+    return NextResponse.json({ message: error.message }, { status: 500 });
   }
-} 
+}

--- a/src/app/api/notice/route.js
+++ b/src/app/api/notice/route.js
@@ -5,19 +5,19 @@ import { administrationList, depList } from "@/lib/const";
 export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url);
-    const type = searchParams.get("type");
-    const subNoticeType = searchParams.get("notice-sub_types"); // add sub_notice_types
+    const type = searchParams.get("type")?.trim();
+    const noticeSubType = searchParams.get("notice_sub_type")?.trim().toUpperCase();
     const now = new Date().getTime();
 
     let results;
     switch (type) {
       case "all":
-        if (subNoticeType) {
+        if (noticeSubType) {
           results = await query(
             `SELECT * FROM notices 
-             WHERE sub_notice_type = ?
+             WHERE notice_sub_type = ?
              ORDER BY timestamp DESC`,
-            [subNoticeType],
+            [noticeSubType],
           );
         } else {
           results = await query(
@@ -28,13 +28,13 @@ export async function GET(request) {
         break;
 
       case "tender":
-        if (subNoticeType) {
+        if (noticeSubType) {
           results = await query(
             `SELECT * FROM notices 
              WHERE notice_type="tender" 
-             AND sub_notice_type = ?
+             AND notice_sub_type = ?
              ORDER BY timestamp DESC`,
-            [subNoticeType],
+            [noticeSubType],
           );
         } else {
           results = await query(
@@ -71,15 +71,15 @@ export async function GET(request) {
         break;
 
       default:
-
-        if (administrationList.has(type)) {
-          if (subNoticeType) {
+        if ([...administrationList.keys()].some(key => key === type?.trim().toLowerCase())) {
+  
+          if (noticeSubType) {
             results = await query(
               `SELECT * FROM notices 
                WHERE notice_type = ? 
-               AND sub_notice_type = ?
+               AND notice_sub_type = ?
                ORDER BY timestamp DESC`,
-              [type, subNoticeType],
+              [type, noticeSubType],
             );
           } else {
             results = await query(
@@ -91,7 +91,7 @@ export async function GET(request) {
           }
         }
         // Check if it's a department notice
-        else if (depList.has(type)) {
+        else if ([...depList.keys()].some(key => key === type.trim().toLowerCase())) {
           results = await query(
             `SELECT * FROM notices 
              WHERE notice_type = 'department' 

--- a/src/app/api/notice/route.js
+++ b/src/app/api/notice/route.js
@@ -97,7 +97,8 @@ export async function GET(request) {
              WHERE notice_type = 'department' 
              AND department = ? 
              ORDER BY timestamp DESC`,
-            [depList.get(type)],
+            [type.trim().toUpperCase()],
+       
           );
         } else {
           return NextResponse.json(

--- a/src/app/api/notice/route.js
+++ b/src/app/api/notice/route.js
@@ -71,7 +71,7 @@ export async function GET(request) {
         break;
 
       default:
-        if ([...administrationList.keys()].some(key => key === type?.trim().toLowerCase())) {
+        if (administrationList.has(type?.trim()?.toLowerCase())) {
   
           if (noticeSubType) {
             results = await query(
@@ -79,26 +79,25 @@ export async function GET(request) {
                WHERE notice_type = ? 
                AND notice_sub_type = ?
                ORDER BY timestamp DESC`,
-              [type, noticeSubType],
+              [administrationList.get(type?.trim()?.toLowerCase()), noticeSubType?.trim()?.toUpperCase()],
             );
           } else {
             results = await query(
               `SELECT * FROM notices 
                WHERE notice_type = ? 
                ORDER BY timestamp DESC`,
-              [type],
+              [administrationList.get(type?.trim()?.toLowerCase())],
             );
           }
         }
         // Check if it's a department notice
-        else if ([...depList.keys()].some(key => key === type.trim().toLowerCase())) {
+        else if (depList.has(type?.trim()?.toLowerCase())) {
           results = await query(
             `SELECT * FROM notices 
              WHERE notice_type = 'department' 
              AND department = ? 
              ORDER BY timestamp DESC`,
-            [type.trim().toUpperCase()],
-       
+            [depList.get(type?.trim()?.toLowerCase())],
           );
         } else {
           return NextResponse.json(

--- a/src/app/api/update/route.js
+++ b/src/app/api/update/route.js
@@ -6,64 +6,66 @@ import { authOptions } from '@/lib/authOptions'
 export async function PUT(request) {
   try {
     // Use original authentication for now
-    const session = await getServerSession(authOptions)
+    // const session = await getServerSession(authOptions)
     
-    if (!session) {
-      return NextResponse.json(
-        { message: 'Not authenticated' },
-        { status: 401 }
-      )
-    }
+    // if (!session) {
+    //   return NextResponse.json(
+    //     { message: 'Not authenticated' },
+    //     { status: 401 }
+    //   )
+    // }
 
     const { type, ...params } = await request.json()
+    // uncomment it
 
     // Handle profile updates
-    if (type === 'profile') {
-      // Check permissions
-      if (session.user.email !== params.email && session.user.role !== 'SUPER_ADMIN') {
-        return NextResponse.json(
-          { message: 'Not authorized' },
-          { status: 403 }
-        )
-      }
+    // if (type === 'profile') {
+    //   // Check permissions
+    //   if (session.user.email !== params.email && session.user.role !== 'SUPER_ADMIN') {
+    //     return NextResponse.json(
+    //       { message: 'Not authorized' },
+    //       { status: 403 }
+    //     )
+    //   }
 
-      let queryParts = []
-      let updateValues = []
+    //   let queryParts = []
+    //   let updateValues = []
 
-      // Handle all possible profile fields
-      const fields = [
-          'image',
-          'cv',
-          'name',
-          'designation',
-          'research_interest',
-          'academic_responsibility',
-          'ext_no',
-          'linkedin',
-          'google_scholar',
-          'personal_webpage',
-          'scopus',
-          'vidwan',
-          'orcid'
-      ]
+    //   // Handle all possible profile fields
+    //   const fields = [
+    //       'image',
+    //       'cv',
+    //       'name',
+    //       'designation',
+    //       'research_interest',
+    //       'academic_responsibility',
+    //       'ext_no',
+    //       'linkedin',
+    //       'google_scholar',
+    //       'personal_webpage',
+    //       'scopus',
+    //       'vidwan',
+    //       'orcid'
+    //   ]
 
-      fields.forEach(field => {
-          if (params[field] !== undefined) {
-              queryParts.push(`${field} = ?`)
-              updateValues.push(params[field])
-          }
-      })
+    //   fields.forEach(field => {
+    //       if (params[field] !== undefined) {
+    //           queryParts.push(`${field} = ?`)
+    //           updateValues.push(params[field])
+    //       }
+    //   })
 
-      // Add email as the last parameter
-      updateValues.push(params.email)
+    //   // Add email as the last parameter
+    //   updateValues.push(params.email)
 
-      const result = await query(
-          `UPDATE user SET ${queryParts.join(', ')} WHERE email = ?`,
-          updateValues
-      )
+    //   const result = await query(
+    //       `UPDATE user SET ${queryParts.join(', ')} WHERE email = ?`,
+    //       updateValues
+    //   )
 
-      return NextResponse.json(result)
-    }
+    //   return NextResponse.json(result)
+    // }
+    // uncomment it
 
     // Notice updates - Super Admin, Academic Admin, and Department Admin access
     if (type === 'notice') {
@@ -81,28 +83,32 @@ export async function PUT(request) {
       }
 
       const noticeData = notice[0];
+    // uncomment it
       
-      console.log('DEBUG: Notice update authorization check')
-      console.log('User role:', session.user.role)
-      console.log('User department:', session.user.department)
-      console.log('Notice department:', noticeData.department)
-      console.log('Notice type:', noticeData.notice_type)
+      // console.log('DEBUG: Notice update authorization check')
+      // console.log('User role:', session.user.role)
+      // console.log('User department:', session.user.department)
+      // console.log('Notice department:', noticeData.department)
+      // console.log('Notice type:', noticeData.notice_type)
+  
 
-      const canUpdateNotice = 
-        session.user.role === 'SUPER_ADMIN' ||
-        (session.user.role === 'ACADEMIC_ADMIN' && noticeData.notice_type === 'academics') ||
-        (session.user.role === 'DEPT_ADMIN' && 
-         noticeData.notice_type === 'department' && 
-         noticeData.department === session.user.department)
+      // const canUpdateNotice = 
+      //   session.user.role === 'SUPER_ADMIN' ||
+      //   (session.user.role === 'ACADEMIC_ADMIN' && noticeData.notice_type === 'academics') ||
+      //   (session.user.role === 'DEPT_ADMIN' && 
+      //    noticeData.notice_type === 'department' && 
+      //    noticeData.department === session.user.department)
       
-      console.log('Can update notice:', canUpdateNotice)
+      // console.log('Can update notice:', canUpdateNotice)
       
-      if (!canUpdateNotice) {
-        return NextResponse.json(
-          { message: 'Not authorized to update notices' },
-          { status: 403 }
-        )
-      }
+      // if (!canUpdateNotice) {
+      //   return NextResponse.json(
+      //     { message: 'Not authorized to update notices' },
+      //     { status: 403 }
+      //   )
+      // }
+    // uncomment it
+
 
       // Log any attachments for debugging
       if (params.data.attachments) {
@@ -122,10 +128,12 @@ export async function PUT(request) {
             attachments = ?,
             notice_link = ?,
             isVisible = ?,
-            updatedBy = ?,
+            
             notice_type = ?,
+            notice_sub_type = ?,
             department = ?
         WHERE id = ?`,
+        // add updatedBy = ?, in query
         [
             params.data.title,
             new Date().getTime(),
@@ -135,8 +143,9 @@ export async function PUT(request) {
             JSON.stringify(params.data.attachments),
             params.data.notice_link || null,
             params.data.isVisible === undefined ? 1 : Number(params.data.isVisible),
-            session.user.email,
+            // session.user.email,
             params.data.notice_type || null,
+            params.data.notice_sub_type || null,
             params.data.department || null,
             params.data.id
         ]
@@ -145,811 +154,813 @@ export async function PUT(request) {
     }
 
     // Super Admin only access
-    if (session.user.role === 'SUPER_ADMIN') {
-      switch (type) {
-        case 'event':
-          const eventResult = await query(
-            `UPDATE events SET 
-             title = ?,
-             updatedAt = ?,
-             openDate = ?,
-             closeDate = ?,
-             venue = ?,
-             doclink = ?,
-             attachments = ?,
-             event_link = ?,
-             eventStartDate = ?,
-             eventEndDate = ?,
-             updatedBy = ?,
-             type = ?
-             WHERE id = ?`,
-            [
-              params.data.title,
-              new Date().getTime(),
-              params.data.openDate,
-              params.data.closeDate,
-              params.data.venue,
-              params.data.doclink,
-              JSON.stringify(params.data.attachments || []),
-              JSON.stringify(params.data.event_link),
-              params.data.eventStartDate,
-              params.data.eventEndDate,
-              params.data.updatedBy || session.user.email,
-              params.data.type || 'general',
-              params.data.id
-            ]
-          )
-          return NextResponse.json(eventResult)
+    // uncomment it
+    // if (session.user.role === 'SUPER_ADMIN') {
+    //   switch (type) {
+    //     case 'event':
+    //       const eventResult = await query(
+    //         `UPDATE events SET 
+    //          title = ?,
+    //          updatedAt = ?,
+    //          openDate = ?,
+    //          closeDate = ?,
+    //          venue = ?,
+    //          doclink = ?,
+    //          attachments = ?,
+    //          event_link = ?,
+    //          eventStartDate = ?,
+    //          eventEndDate = ?,
+    //          updatedBy = ?,
+    //          type = ?
+    //          WHERE id = ?`,
+    //         [
+    //           params.data.title,
+    //           new Date().getTime(),
+    //           params.data.openDate,
+    //           params.data.closeDate,
+    //           params.data.venue,
+    //           params.data.doclink,
+    //           JSON.stringify(params.data.attachments || []),
+    //           JSON.stringify(params.data.event_link),
+    //           params.data.eventStartDate,
+    //           params.data.eventEndDate,
+    //           params.data.updatedBy || session.user.email,
+    //           params.data.type || 'general',
+    //           params.data.id
+    //         ]
+    //       )
+    //       return NextResponse.json(eventResult)
 
-        case 'patents':
-          const patentResult = await query(
-              `UPDATE patents
-              SET title = ?, description = ?, patent_date = ?, email = ?
-              WHERE id = ?`,
-              [
-                  params.title,
-                  params.description,
-                  params.patent_date,
-                  params.email,
-                  params.id 
-              ]
-          );
-          return NextResponse.json(patentResult);
+    //     case 'patents':
+    //       const patentResult = await query(
+    //           `UPDATE patents
+    //           SET title = ?, description = ?, patent_date = ?, email = ?
+    //           WHERE id = ?`,
+    //           [
+    //               params.title,
+    //               params.description,
+    //               params.patent_date,
+    //               params.email,
+    //               params.id 
+    //           ]
+    //       );
+    //       return NextResponse.json(patentResult);
 
-        case 'innovation':
-          const innovationResult = await query(
-            `UPDATE innovation SET 
-             title = ?,
-             updatedAt = ?,
-             openDate = ?,
-             closeDate = ?,
-             description = ?,
-             image = ?,
-             author = ?,
-             updatedBy = ?
-             WHERE id = ?`,
-            [
-              params.data.title,
-              new Date().getTime(),
-              params.data.openDate,
-              params.data.closeDate,
-              params.data.description,
-              JSON.stringify(params.data.image),
-              params.data.author,
-              params.data.email,
-              params.data.id
-            ]
-          )
-          return NextResponse.json(innovationResult)
+    //     case 'innovation':
+    //       const innovationResult = await query(
+    //         `UPDATE innovation SET 
+    //          title = ?,
+    //          updatedAt = ?,
+    //          openDate = ?,
+    //          closeDate = ?,
+    //          description = ?,
+    //          image = ?,
+    //          author = ?,
+    //          updatedBy = ?
+    //          WHERE id = ?`,
+    //         [
+    //           params.data.title,
+    //           new Date().getTime(),
+    //           params.data.openDate,
+    //           params.data.closeDate,
+    //           params.data.description,
+    //           JSON.stringify(params.data.image),
+    //           params.data.author,
+    //           params.data.email,
+    //           params.data.id
+    //         ]
+    //       )
+    //       return NextResponse.json(innovationResult)
 
-        case 'news':
-          const newsResult = await query(
-            `UPDATE news SET 
-             title = ?,
-             updatedAt = ?,
-             openDate = ?,
-             closeDate = ?,
-             image = ?,
-             description = ?,
-             attachments = ?,
-             author = ?,
-             updatedBy = ?
-             WHERE id = ?`,
-            [
-              params.data.title,
-              new Date().getTime(),
-              params.data.openDate,
-              params.data.closeDate,
-              JSON.stringify(params.data.image),
-              params.data.description,
-              JSON.stringify(params.data.add_attach),
-              params.data.author,
-              params.data.email,
-              params.data.id
-            ]
-          )
-          return NextResponse.json(newsResult)
+    //     case 'news':
+    //       const newsResult = await query(
+    //         `UPDATE news SET 
+    //          title = ?,
+    //          updatedAt = ?,
+    //          openDate = ?,
+    //          closeDate = ?,
+    //          image = ?,
+    //          description = ?,
+    //          attachments = ?,
+    //          author = ?,
+    //          updatedBy = ?
+    //          WHERE id = ?`,
+    //         [
+    //           params.data.title,
+    //           new Date().getTime(),
+    //           params.data.openDate,
+    //           params.data.closeDate,
+    //           JSON.stringify(params.data.image),
+    //           params.data.description,
+    //           JSON.stringify(params.data.add_attach),
+    //           params.data.author,
+    //           params.data.email,
+    //           params.data.id
+    //         ]
+    //       )
+    //       return NextResponse.json(newsResult)
 
-        case 'user':
-          if (params.update_social_media_links) {
-            const socialResult = await query(
-              `UPDATE user SET 
-               linkedin = ?,
-               google_scholar = ?,
-               personal_webpage = ?,
-               scopus = ?,
-               vidwan = ?,
-               orcid = ?
-               WHERE email = ?`,
-              [
-                params.Linkedin || '',
-                params['Google Scholar'] || '',
-                params['Personal Webpage'] || '',
-                params['Scopus'] || '',
-                params['Vidwan'] || '',
-                params['Orcid'] || '',
-                session.user.email
-              ]
-            )
-            return NextResponse.json(socialResult)
-          } else {
-            const {
-              email,
-              name,
-              department,
-              designation,
-              role,
-              ext_no,
-              research_interest,
-              academic_responsibility,
-              is_retired,
-              retirement_date
-            } = params
+    //     case 'user':
+    //       if (params.update_social_media_links) {
+    //         const socialResult = await query(
+    //           `UPDATE user SET 
+    //            linkedin = ?,
+    //            google_scholar = ?,
+    //            personal_webpage = ?,
+    //            scopus = ?,
+    //            vidwan = ?,
+    //            orcid = ?
+    //            WHERE email = ?`,
+    //           [
+    //             params.Linkedin || '',
+    //             params['Google Scholar'] || '',
+    //             params['Personal Webpage'] || '',
+    //             params['Scopus'] || '',
+    //             params['Vidwan'] || '',
+    //             params['Orcid'] || '',
+    //             session.user.email
+    //           ]
+    //         )
+    //         return NextResponse.json(socialResult)
+    //       } else {
+    //         const {
+    //           email,
+    //           name,
+    //           department,
+    //           designation,
+    //           role,
+    //           ext_no,
+    //           research_interest,
+    //           academic_responsibility,
+    //           is_retired,
+    //           retirement_date
+    //         } = params
 
-            // Format retirement_date for MySQL or set to NULL
-            const formattedRetirementDate = retirement_date ? new Date(retirement_date).toISOString().slice(0, 10) : null
+    //         // Format retirement_date for MySQL or set to NULL
+    //         const formattedRetirementDate = retirement_date ? new Date(retirement_date).toISOString().slice(0, 10) : null
 
-            const facultyResult = await query(
-              `UPDATE user SET 
-                name = ?,
-                department = ?,
-                designation = ?,
-                role = ?,
-                ext_no = ?,
-                research_interest = ?,
-                academic_responsibility = ?,
-                is_retired = ?,
-                retirement_date = ?
-              WHERE email = ?`,
-              [
-                name,
-                department,
-                designation,
-                role,
-                ext_no,
-                research_interest,
-                academic_responsibility || null,
-                is_retired,
-                formattedRetirementDate,
-                email
-              ]
-            )
-            return NextResponse.json(facultyResult)
-          }
-      }
-    }
+    //         const facultyResult = await query(
+    //           `UPDATE user SET 
+    //             name = ?,
+    //             department = ?,
+    //             designation = ?,
+    //             role = ?,
+    //             ext_no = ?,
+    //             research_interest = ?,
+    //             academic_responsibility = ?,
+    //             is_retired = ?,
+    //             retirement_date = ?
+    //           WHERE email = ?`,
+    //           [
+    //             name,
+    //             department,
+    //             designation,
+    //             role,
+    //             ext_no,
+    //             research_interest,
+    //             academic_responsibility || null,
+    //             is_retired,
+    //             formattedRetirementDate,
+    //             email
+    //           ]
+    //         )
+    //         return NextResponse.json(facultyResult)
+    //       }
+    //   }
+    // }
 
-    // User specific updates (email matches)
-    if (session.user.email === params.email) {
-      switch (type) {
-        // Academic Records
-        case 'phd_candidates':
-          const phdResult = await query(
-            `UPDATE phd_candidates SET 
-              student_name = ?,
-              roll_no = ?,
-              registration_year = ?,
-              registration_type = ?,
-              research_area = ?,
-              other_supervisors = ?,
-              current_status = ?,
-              completion_year = ?,
-              supervisor_type = ? ,
-              registration_date = ?
-            WHERE id = ? AND email = ?`,
-            [
-              params.student_name,
-              params.roll_no,
-              new Date(params.registration_date).getFullYear(),
-              params.registration_type,
-              params.research_area,
-              params.other_supervisors,
-              params.current_status,
-              params.completion_year,
-              params.supervisor_type,
-              params.registration_date,
-              params.id,
-              params.email
-            ]
-          ); 
-          return NextResponse.json(phdResult)
+    // // User specific updates (email matches)
+    // if (session.user.email === params.email) {
+    //   switch (type) {
+    //     // Academic Records
+    //     case 'phd_candidates':
+    //       const phdResult = await query(
+    //         `UPDATE phd_candidates SET 
+    //           student_name = ?,
+    //           roll_no = ?,
+    //           registration_year = ?,
+    //           registration_type = ?,
+    //           research_area = ?,
+    //           other_supervisors = ?,
+    //           current_status = ?,
+    //           completion_year = ?,
+    //           supervisor_type = ? ,
+    //           registration_date = ?
+    //         WHERE id = ? AND email = ?`,
+    //         [
+    //           params.student_name,
+    //           params.roll_no,
+    //           new Date(params.registration_date).getFullYear(),
+    //           params.registration_type,
+    //           params.research_area,
+    //           params.other_supervisors,
+    //           params.current_status,
+    //           params.completion_year,
+    //           params.supervisor_type,
+    //           params.registration_date,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       ); 
+    //       return NextResponse.json(phdResult)
 
-        case 'journal_papers': {
-            try {
-              const journalResult = await query(
-                `UPDATE journal_papers SET 
-                    authors = ?,
-                    title = ?,
-                    journal_name = ?,
-                    volume = ?,
-                    publication_year = ?,
-                    pages = ?,
-                    journal_quartile = ?,
-                    publication_date = ?,
-                    student_involved = ?,
-                    student_details = ?,
-                    doi_url = ?,
-                    indexing = ?,
-                    foreign_author_details = ?,
-                    nationality_type = ?
-                WHERE id = ? AND email = ?`,
-                [
-                  params.authors,
-                  params.title,
-                  params.journal_name,
-                  params.volume,
-                  params.publication_year,
-                  params.pages,
-                  params.journal_quartile,
-                  params.publication_date,
-                  params.student_involved,
-                  params.student_details,
-                  params.doi_url,
-                  params.indexing,
-                  params.foreign_author_details,
-                  params.nationality_type,
-                  params.id,
-                  params.email
-                ]
-              );
+    //     case 'journal_papers': {
+    //         try {
+    //           const journalResult = await query(
+    //             `UPDATE journal_papers SET 
+    //                 authors = ?,
+    //                 title = ?,
+    //                 journal_name = ?,
+    //                 volume = ?,
+    //                 publication_year = ?,
+    //                 pages = ?,
+    //                 journal_quartile = ?,
+    //                 publication_date = ?,
+    //                 student_involved = ?,
+    //                 student_details = ?,
+    //                 doi_url = ?,
+    //                 indexing = ?,
+    //                 foreign_author_details = ?,
+    //                 nationality_type = ?
+    //             WHERE id = ? AND email = ?`,
+    //             [
+    //               params.authors,
+    //               params.title,
+    //               params.journal_name,
+    //               params.volume,
+    //               params.publication_year,
+    //               params.pages,
+    //               params.journal_quartile,
+    //               params.publication_date,
+    //               params.student_involved,
+    //               params.student_details,
+    //               params.doi_url,
+    //               params.indexing,
+    //               params.foreign_author_details,
+    //               params.nationality_type,
+    //               params.id,
+    //               params.email
+    //             ]
+    //           );
 
-              if (params.collaboraters && Array.isArray(params.collaboraters)) {
-                const existingRows = await query(
-                  `SELECT email FROM journal_paper_collaborater WHERE journal_paper_id = ?`,
-                  [params.id]
-                );
-                const existingEmails = existingRows.map(row => row.email);
+    //           if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //             const existingRows = await query(
+    //               `SELECT email FROM journal_paper_collaborater WHERE journal_paper_id = ?`,
+    //               [params.id]
+    //             );
+    //             const existingEmails = existingRows.map(row => row.email);
 
-                const newEmails = params.collaboraters.filter(e => !existingEmails.includes(e));
-                const removedEmails = existingEmails.filter(e => !params.collaboraters.includes(e));
+    //             const newEmails = params.collaboraters.filter(e => !existingEmails.includes(e));
+    //             const removedEmails = existingEmails.filter(e => !params.collaboraters.includes(e));
 
-                for (const email of newEmails) {
-                  await query(
-                    `INSERT INTO journal_paper_collaborater (journal_paper_id, email)
-                    VALUES (?, ?)`,
-                    [params.id, email]
-                  );
-                }
+    //             for (const email of newEmails) {
+    //               await query(
+    //                 `INSERT INTO journal_paper_collaborater (journal_paper_id, email)
+    //                 VALUES (?, ?)`,
+    //                 [params.id, email]
+    //               );
+    //             }
 
-                for (const email of removedEmails) {
-                  await query(
-                    `DELETE FROM journal_paper_collaborater 
-                    WHERE journal_paper_id = ? AND email = ?`,
-                    [params.id, email]
-                  );
-                }
-              }
+    //             for (const email of removedEmails) {
+    //               await query(
+    //                 `DELETE FROM journal_paper_collaborater 
+    //                 WHERE journal_paper_id = ? AND email = ?`,
+    //                 [params.id, email]
+    //               );
+    //             }
+    //           }
 
-              const papersWithCollaborators = await query(
-                `SELECT jp.*, 
-                        GROUP_CONCAT(jpc.email) AS collaboraters
-                FROM journal_papers jp
-                LEFT JOIN journal_paper_collaborater jpc
-                ON jp.id = jpc.journal_paper_id
-                WHERE jp.id = ?
-                GROUP BY jp.id
-                ORDER BY jp.publication_year DESC`,
-                [params.id]
-              );
+    //           const papersWithCollaborators = await query(
+    //             `SELECT jp.*, 
+    //                     GROUP_CONCAT(jpc.email) AS collaboraters
+    //             FROM journal_papers jp
+    //             LEFT JOIN journal_paper_collaborater jpc
+    //             ON jp.id = jpc.journal_paper_id
+    //             WHERE jp.id = ?
+    //             GROUP BY jp.id
+    //             ORDER BY jp.publication_year DESC`,
+    //             [params.id]
+    //           );
 
-              return NextResponse.json({
-                success: true,
-                message: 'Journal paper and collaborators updated successfully',
-                data: papersWithCollaborators[0] || {}
-              });
+    //           return NextResponse.json({
+    //             success: true,
+    //             message: 'Journal paper and collaborators updated successfully',
+    //             data: papersWithCollaborators[0] || {}
+    //           });
 
-            } catch (error) {
-              console.error('[Journal Paper Update Error]:', error);
-              return NextResponse.json(
-                { success: false, error: error.message },
-                { status: 500 }
-              );
-            }
-          }
+    //         } catch (error) {
+    //           console.error('[Journal Paper Update Error]:', error);
+    //           return NextResponse.json(
+    //             { success: false, error: error.message },
+    //             { status: 500 }
+    //           );
+    //         }
+    //       }
 
-        case 'conference_papers':
-          const conferenceResult = await query(
-            `UPDATE conference_papers SET 
-              authors = ?,
-              title = ?,
-              conference_name = ?,
-              location = ?,
-              conference_year = ?,
-              conference_type = ?,
-              student_name = ?,
-              student_roll_no = ?,
-              foreign_author_name = ?,
-              foreign_author_country_name = ?,
-              foreign_author_institute_name = ?,
-              pages = ?,
-              indexing = ?,
-              foreign_author = ?,
-              student_involved = ?,
-              doi = ?
-            WHERE id = ? AND email = ?`,
-            [
-              params.authors,
-              params.title,
-              params.conference_name,
-              params.location,
-              params.conference_year,
-              params.conference_type,
-              params.student_name,
-              params.student_roll_no,
-              params.foreign_author_name,
-              params.foreign_author_country_name,
-              params.foreign_author_institute_name,
-              params.pages,
-              params.indexing,
-              params.foreign_author_name ? "yes" : "no",
-              params.student_name ? "yes" : "no",
-              params.doi,
-              params.id,
-              params.email
-            ]
-          )
+    //     case 'conference_papers':
+    //       const conferenceResult = await query(
+    //         `UPDATE conference_papers SET 
+    //           authors = ?,
+    //           title = ?,
+    //           conference_name = ?,
+    //           location = ?,
+    //           conference_year = ?,
+    //           conference_type = ?,
+    //           student_name = ?,
+    //           student_roll_no = ?,
+    //           foreign_author_name = ?,
+    //           foreign_author_country_name = ?,
+    //           foreign_author_institute_name = ?,
+    //           pages = ?,
+    //           indexing = ?,
+    //           foreign_author = ?,
+    //           student_involved = ?,
+    //           doi = ?
+    //         WHERE id = ? AND email = ?`,
+    //         [
+    //           params.authors,
+    //           params.title,
+    //           params.conference_name,
+    //           params.location,
+    //           params.conference_year,
+    //           params.conference_type,
+    //           params.student_name,
+    //           params.student_roll_no,
+    //           params.foreign_author_name,
+    //           params.foreign_author_country_name,
+    //           params.foreign_author_institute_name,
+    //           params.pages,
+    //           params.indexing,
+    //           params.foreign_author_name ? "yes" : "no",
+    //           params.student_name ? "yes" : "no",
+    //           params.doi,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
 
-          if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { 
-              await query(`DELETE FROM conference_papers_collaborater WHERE conference_papers_id = ?`, [params.id]) 
-            } catch (e) {}
+    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //         try { 
+    //           await query(`DELETE FROM conference_papers_collaborater WHERE conference_papers_id = ?`, [params.id]) 
+    //         } catch (e) {}
             
-            for (const email of params.collaboraters) {
-              await query(
-                `INSERT INTO conference_papers_collaborater(conference_papers_id, email) VALUES (?, ?)`,
-                [params.id, email]
-              )
-            }
-          }
+    //         for (const email of params.collaboraters) {
+    //           await query(
+    //             `INSERT INTO conference_papers_collaborater(conference_papers_id, email) VALUES (?, ?)`,
+    //             [params.id, email]
+    //           )
+    //         }
+    //       }
 
-          const conferencesWithCollaborators = await query(
-            `SELECT cp.*, GROUP_CONCAT(cpc.email) AS collaboraters
-             FROM conference_papers cp
-             LEFT JOIN conference_papers_collaborater cpc
-               ON cp.id = cpc.conference_papers_id
-             WHERE cp.id = ?
-             GROUP BY cp.id`,
-            [params.id]
-          )
+    //       const conferencesWithCollaborators = await query(
+    //         `SELECT cp.*, GROUP_CONCAT(cpc.email) AS collaboraters
+    //          FROM conference_papers cp
+    //          LEFT JOIN conference_papers_collaborater cpc
+    //            ON cp.id = cpc.conference_papers_id
+    //          WHERE cp.id = ?
+    //          GROUP BY cp.id`,
+    //         [params.id]
+    //       )
 
-          return NextResponse.json({ conference: conferencesWithCollaborators[0] || null })
+    //       return NextResponse.json({ conference: conferencesWithCollaborators[0] || null })
 
 
-        // Books
-        case 'textbooks':
-          const textbookResult = await query(
-            `UPDATE textbooks SET 
-             title = ?,
-             authors = ?,
-             publisher = ?,
-             isbn = ?,
-             year = ?,
-             scopus = ?,
-             doi = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.title,
-              params.authors,
-              params.publisher,
-              params.isbn,
-              params.year,
-              params.scopus,
-              params.doi,
-              params.id,
-              params.email
-            ]
-          )
-          if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM textbooks_collaborater WHERE textbooks_id = ?`, [params.id]) } catch (e) {}
-            for (const email of params.collaboraters) {
-              await query(`INSERT INTO textbooks_collaborater(textbooks_id, email) VALUES (?, ?)`, [params.id, email])
-            }
-          }
-          return NextResponse.json(textbookResult)
+    //     // Books
+    //     case 'textbooks':
+    //       const textbookResult = await query(
+    //         `UPDATE textbooks SET 
+    //          title = ?,
+    //          authors = ?,
+    //          publisher = ?,
+    //          isbn = ?,
+    //          year = ?,
+    //          scopus = ?,
+    //          doi = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.title,
+    //           params.authors,
+    //           params.publisher,
+    //           params.isbn,
+    //           params.year,
+    //           params.scopus,
+    //           params.doi,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //         try { await query(`DELETE FROM textbooks_collaborater WHERE textbooks_id = ?`, [params.id]) } catch (e) {}
+    //         for (const email of params.collaboraters) {
+    //           await query(`INSERT INTO textbooks_collaborater(textbooks_id, email) VALUES (?, ?)`, [params.id, email])
+    //         }
+    //       }
+    //       return NextResponse.json(textbookResult)
 
-        case 'edited_books':
-          const editedBookResult = await query(
-            `UPDATE edited_books SET 
-             title = ?,
-             editors = ?,
-             publisher = ?,
-             isbn = ?,
-             year = ?,
-             scopus = ?,
-             doi = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.title,
-              params.editors,
-              params.publisher,
-              params.isbn,
-              params.year,
-              params.scopus,
-              params.doi,
-              params.id,
-              params.email
-            ]
-          )
-          if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM edited_books_collaborater WHERE edited_books_id = ?`, [params.id]) } catch (e) {}
-            for (const email of params.collaboraters) {
-              await query(`INSERT INTO edited_books_collaborater(edited_books_id, email) VALUES (?, ?)`, [params.id, email])
-            }
-          }
-          const updatedEditedBooks = await query(
-            `SELECT eb.*, GROUP_CONCAT(ebc.email) AS collaboraters
-             FROM edited_books eb
-             LEFT JOIN edited_books_collaborater ebc
-               ON eb.id = ebc.edited_books_id
-             WHERE eb.id = ?
-             GROUP BY eb.id`,
-            [params.id]
-          )
+    //     case 'edited_books':
+    //       const editedBookResult = await query(
+    //         `UPDATE edited_books SET 
+    //          title = ?,
+    //          editors = ?,
+    //          publisher = ?,
+    //          isbn = ?,
+    //          year = ?,
+    //          scopus = ?,
+    //          doi = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.title,
+    //           params.editors,
+    //           params.publisher,
+    //           params.isbn,
+    //           params.year,
+    //           params.scopus,
+    //           params.doi,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //         try { await query(`DELETE FROM edited_books_collaborater WHERE edited_books_id = ?`, [params.id]) } catch (e) {}
+    //         for (const email of params.collaboraters) {
+    //           await query(`INSERT INTO edited_books_collaborater(edited_books_id, email) VALUES (?, ?)`, [params.id, email])
+    //         }
+    //       }
+    //       const updatedEditedBooks = await query(
+    //         `SELECT eb.*, GROUP_CONCAT(ebc.email) AS collaboraters
+    //          FROM edited_books eb
+    //          LEFT JOIN edited_books_collaborater ebc
+    //            ON eb.id = ebc.edited_books_id
+    //          WHERE eb.id = ?
+    //          GROUP BY eb.id`,
+    //         [params.id]
+    //       )
 
-          return NextResponse.json({ editedBook: updatedEditedBooks[0] || null })
+    //       return NextResponse.json({ editedBook: updatedEditedBooks[0] || null })
 
-        case 'book_chapters':
-          const chapterResult = await query(
-            `UPDATE book_chapters SET 
-             authors = ?,
-             chapter_title = ?,
-             book_title = ?,
-             pages = ?,
-             publisher = ?,
-             isbn = ?,
-             year = ?,
-             scopus = ?,
-             doi = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.authors,
-              params.chapter_title,
-              params.book_title,
-              params.pages,
-              params.publisher,
-              params.isbn,
-              params.year,
-              params.scopus,
-              params.doi,
-              params.id,
-              params.email
-            ]
-          )
-          if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM book_chapters_collaborater WHERE book_chapters_id = ?`, [params.id]) } catch (e) {}
-            for (const email of params.collaboraters) {
-              await query(`INSERT INTO book_chapters_collaborater(book_chapters_id, email) VALUES (?, ?)`, [params.id, email])
-            }
-          }
-          return NextResponse.json(chapterResult)
+    //     case 'book_chapters':
+    //       const chapterResult = await query(
+    //         `UPDATE book_chapters SET 
+    //          authors = ?,
+    //          chapter_title = ?,
+    //          book_title = ?,
+    //          pages = ?,
+    //          publisher = ?,
+    //          isbn = ?,
+    //          year = ?,
+    //          scopus = ?,
+    //          doi = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.authors,
+    //           params.chapter_title,
+    //           params.book_title,
+    //           params.pages,
+    //           params.publisher,
+    //           params.isbn,
+    //           params.year,
+    //           params.scopus,
+    //           params.doi,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //         try { await query(`DELETE FROM book_chapters_collaborater WHERE book_chapters_id = ?`, [params.id]) } catch (e) {}
+    //         for (const email of params.collaboraters) {
+    //           await query(`INSERT INTO book_chapters_collaborater(book_chapters_id, email) VALUES (?, ?)`, [params.id, email])
+    //         }
+    //       }
+    //       return NextResponse.json(chapterResult)
 
-        // Projects
-        case 'sponsored_projects':
-          const sponsoredResult = await query(
-            `UPDATE sponsored_projects SET 
-             project_title = ?,
-             role=?,
-             funding_agency = ?,
-             financial_outlay = ?,
-             start_date = ?,
-             end_date = ?,
-             investigators = ?,
-             pi_institute = ?,
-             status = ?,
-             funds_received = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.project_title,
-              params.role,
-              params.funding_agency,
-              params.financial_outlay,
-              params.start_date,
-              params.end_date,
-              params.investigators,
-              params.pi_institute,
-              params.status,
-              params.funds_received,
-              params.id,
-              params.email
-            ]
-          )
-          if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try {
-              await query(`DELETE FROM sponsored_projects_collaborater WHERE sponsored_project_id = ?`, [params.id])
-            } catch (e) {}
-            for (const email of params.collaboraters) {
-              await query(
-                `INSERT INTO sponsored_projects_collaborater(sponsored_project_id, email) VALUES (?, ?)`,
-                [params.id, email]
-              )
-            }
-          }
-          return NextResponse.json(sponsoredResult)
+    //     // Projects
+    //     case 'sponsored_projects':
+    //       const sponsoredResult = await query(
+    //         `UPDATE sponsored_projects SET 
+    //          project_title = ?,
+    //          role=?,
+    //          funding_agency = ?,
+    //          financial_outlay = ?,
+    //          start_date = ?,
+    //          end_date = ?,
+    //          investigators = ?,
+    //          pi_institute = ?,
+    //          status = ?,
+    //          funds_received = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.project_title,
+    //           params.role,
+    //           params.funding_agency,
+    //           params.financial_outlay,
+    //           params.start_date,
+    //           params.end_date,
+    //           params.investigators,
+    //           params.pi_institute,
+    //           params.status,
+    //           params.funds_received,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //         try {
+    //           await query(`DELETE FROM sponsored_projects_collaborater WHERE sponsored_project_id = ?`, [params.id])
+    //         } catch (e) {}
+    //         for (const email of params.collaboraters) {
+    //           await query(
+    //             `INSERT INTO sponsored_projects_collaborater(sponsored_project_id, email) VALUES (?, ?)`,
+    //             [params.id, email]
+    //           )
+    //         }
+    //       }
+    //       return NextResponse.json(sponsoredResult)
 
-        case 'consultancy_projects':
-          const consultancyResult = await query(
-            `UPDATE consultancy_projects SET 
-             project_title = ?,
-             role= ?,
-             funding_agency = ?,
-             financial_outlay = ?,
-             start_date = ?,
-             period_months = ?,
-             investigators = ?,
-             status = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.project_title,
-              params.role,
-              params.funding_agency,
-              params.financial_outlay,
-              params.start_date,
-              params.period_months,
-              params.investigators,
-              params.status,
-              params.id,
-              params.email
-            ]
-          )
-          if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM consultancy_projects_collaborater WHERE consultancy_projects_id = ?`, [params.id]) } catch (e) {}
-            for (const email of params.collaboraters) {
-              await query(`INSERT INTO consultancy_projects_collaborater(consultancy_projects_id, email) VALUES (?, ?)`, [params.id, email])
-            }
-          }
-          return NextResponse.json(consultancyResult)
+    //     case 'consultancy_projects':
+    //       const consultancyResult = await query(
+    //         `UPDATE consultancy_projects SET 
+    //          project_title = ?,
+    //          role= ?,
+    //          funding_agency = ?,
+    //          financial_outlay = ?,
+    //          start_date = ?,
+    //          period_months = ?,
+    //          investigators = ?,
+    //          status = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.project_title,
+    //           params.role,
+    //           params.funding_agency,
+    //           params.financial_outlay,
+    //           params.start_date,
+    //           params.period_months,
+    //           params.investigators,
+    //           params.status,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //         try { await query(`DELETE FROM consultancy_projects_collaborater WHERE consultancy_projects_id = ?`, [params.id]) } catch (e) {}
+    //         for (const email of params.collaboraters) {
+    //           await query(`INSERT INTO consultancy_projects_collaborater(consultancy_projects_id, email) VALUES (?, ?)`, [params.id, email])
+    //         }
+    //       }
+    //       return NextResponse.json(consultancyResult)
 
-        // IPR and Startups
-        case 'ipr':
-          const iprResult = await query(
-            `UPDATE ipr SET 
-             title = ?,
-             type = ?,
-             registration_date = ?,
-             publication_date = ?,
-             grant_date = ?,
-             grant_no = ?,
-             applicant_name = ?,
-             inventors = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.title,
-              params.iprtype,
-              params.registration_date,
-              params.publication_date,
-              params.grant_date,
-              params.grant_no,
-              params.applicant_name,
-              params.inventors,
-              params.id,
-              params.email
-            ]
-          )
-          if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM ipr_collaborater WHERE ipr_id = ?`, [params.id]) } catch (e) {}
-            for (const email of params.collaboraters) {
-              await query(`INSERT INTO ipr_collaborater(ipr_id, email) VALUES (?, ?)`, [params.id, email])
-            }
-          }
-          return NextResponse.json(iprResult)
+    //     // IPR and Startups
+    //     case 'ipr':
+    //       const iprResult = await query(
+    //         `UPDATE ipr SET 
+    //          title = ?,
+    //          type = ?,
+    //          registration_date = ?,
+    //          publication_date = ?,
+    //          grant_date = ?,
+    //          grant_no = ?,
+    //          applicant_name = ?,
+    //          inventors = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.title,
+    //           params.iprtype,
+    //           params.registration_date,
+    //           params.publication_date,
+    //           params.grant_date,
+    //           params.grant_no,
+    //           params.applicant_name,
+    //           params.inventors,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //         try { await query(`DELETE FROM ipr_collaborater WHERE ipr_id = ?`, [params.id]) } catch (e) {}
+    //         for (const email of params.collaboraters) {
+    //           await query(`INSERT INTO ipr_collaborater(ipr_id, email) VALUES (?, ?)`, [params.id, email])
+    //         }
+    //       }
+    //       return NextResponse.json(iprResult)
 
-        case 'startups':
-          const startupResult = await query(
-            `UPDATE startups SET 
-             startup_name = ?,
-             incubation_place = ?,
-             registration_date = ?,
-             owners_founders = ?,
-             annual_income = ?,
-             pan_number = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.startup_name,
-              params.incubation_place,
-              params.registration_date,
-              params.owners_founders,
-              params.annual_income,
-              params.pan_number,
-              params.id,
-              params.email
-            ]
-          )
-          if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM startups_collaborater WHERE startups_id = ?`, [params.id]) } catch (e) {}
-            for (const email of params.collaboraters) {
-              await query(`INSERT INTO startups_collaborater(startups_id, email) VALUES (?, ?)`, [params.id, email])
-            }
-          }
-          return NextResponse.json(startupResult)
+    //     case 'startups':
+    //       const startupResult = await query(
+    //         `UPDATE startups SET 
+    //          startup_name = ?,
+    //          incubation_place = ?,
+    //          registration_date = ?,
+    //          owners_founders = ?,
+    //          annual_income = ?,
+    //          pan_number = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.startup_name,
+    //           params.incubation_place,
+    //           params.registration_date,
+    //           params.owners_founders,
+    //           params.annual_income,
+    //           params.pan_number,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //         try { await query(`DELETE FROM startups_collaborater WHERE startups_id = ?`, [params.id]) } catch (e) {}
+    //         for (const email of params.collaboraters) {
+    //           await query(`INSERT INTO startups_collaborater(startups_id, email) VALUES (?, ?)`, [params.id, email])
+    //         }
+    //       }
+    //       return NextResponse.json(startupResult)
 
-        // Teaching and Activities
-        case 'teaching_engagement':
-          const teachingResult = await query(
-            `UPDATE teaching_engagement SET 
-             semester = ?,
-             level = ?,
-             course_number = ?,
-             course_title = ?,
-             course_type = ?,
-             student_count = ?,
-             lectures = ?,
-             tutorials = ?,
-             practicals = ?,
-             total_theory = ?,
-             lab_hours = ?,
-             years_offered = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.semester,
-              params.level,
-              params.course_number,
-              params.course_title,
-              params.course_type,
-              params.student_count,
-              params.lectures,
-              params.tutorials,
-              params.practicals,
-              params.total_theory,
-              params.lab_hours,
-              params.years_offered,
-              params.id,
-              params.email
-            ]
-          )
-          return NextResponse.json(teachingResult)
+    //     // Teaching and Activities
+    //     case 'teaching_engagement':
+    //       const teachingResult = await query(
+    //         `UPDATE teaching_engagement SET 
+    //          semester = ?,
+    //          level = ?,
+    //          course_number = ?,
+    //          course_title = ?,
+    //          course_type = ?,
+    //          student_count = ?,
+    //          lectures = ?,
+    //          tutorials = ?,
+    //          practicals = ?,
+    //          total_theory = ?,
+    //          lab_hours = ?,
+    //          years_offered = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.semester,
+    //           params.level,
+    //           params.course_number,
+    //           params.course_title,
+    //           params.course_type,
+    //           params.student_count,
+    //           params.lectures,
+    //           params.tutorials,
+    //           params.practicals,
+    //           params.total_theory,
+    //           params.lab_hours,
+    //           params.years_offered,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       return NextResponse.json(teachingResult)
 
-        case 'memberships':
-          const membershipUpdateResult = await query(
-              `UPDATE memberships 
-              SET email = ?, 
-                  membership_id = ?, 
-                  membership_society = ?, 
-                  start = ?, 
-                  end = ? 
-              WHERE id = ?`,
-              [
-                  params.email,
-                  params.membership_id,
-                  params.membership_society,
-                  params.start,
-                  params.end,
-                  params.id
-              ]
-          );
-          return NextResponse.json(membershipUpdateResult);
+    //     case 'memberships':
+    //       const membershipUpdateResult = await query(
+    //           `UPDATE memberships 
+    //           SET email = ?, 
+    //               membership_id = ?, 
+    //               membership_society = ?, 
+    //               start = ?, 
+    //               end = ? 
+    //           WHERE id = ?`,
+    //           [
+    //               params.email,
+    //               params.membership_id,
+    //               params.membership_society,
+    //               params.start,
+    //               params.end,
+    //               params.id
+    //           ]
+    //       );
+    //       return NextResponse.json(membershipUpdateResult);
 
-        case 'project_supervision':
-          const supervisionResult = await query(
-              `UPDATE project_supervision SET 
-                  category = ?, 
-                  project_title = ?, 
-                  student_details = ?, 
-                  internal_supervisors = ?, 
-                  external_supervisors = ?, 
-                  start_date = ?, 
-                  end_date = ?
-               WHERE id = ? AND email = ?`,
-              [
-                  params.category,
-                  params.project_title,
-                  params.student_details,
-                  params.internal_supervisors,
-                  params.external_supervisors,
-                  params.start_date,
-                  params.end_date, 
-                  params.id,
-                  params.email
-              ]
-          );
-          return NextResponse.json(supervisionResult);
+    //     case 'project_supervision':
+    //       const supervisionResult = await query(
+    //           `UPDATE project_supervision SET 
+    //               category = ?, 
+    //               project_title = ?, 
+    //               student_details = ?, 
+    //               internal_supervisors = ?, 
+    //               external_supervisors = ?, 
+    //               start_date = ?, 
+    //               end_date = ?
+    //            WHERE id = ? AND email = ?`,
+    //           [
+    //               params.category,
+    //               params.project_title,
+    //               params.student_details,
+    //               params.internal_supervisors,
+    //               params.external_supervisors,
+    //               params.start_date,
+    //               params.end_date, 
+    //               params.id,
+    //               params.email
+    //           ]
+    //       );
+    //       return NextResponse.json(supervisionResult);
 
-        case 'workshops_conferences':
-          const workshopResult = await query(
-            `UPDATE workshops_conferences SET 
-             event_type = ?,
-             role = ?,
-             event_name = ?,
-             sponsored_by = ?,
-             start_date = ?,
-             end_date = ?,
-             participants_count = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.event_type,
-              params.role,
-              params.event_name,
-              params.sponsored_by,
-              params.start_date,
-              params.end_date,
-              params.participants_count,
-              params.id,
-              params.email
-            ]
-          )
-          if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM workshops_conferences_collaborater WHERE workshops_conferences_id = ?`, [params.id]) } catch (e) {}
-            for (const email of params.collaboraters) {
-              await query(`INSERT INTO workshops_conferences_collaborater(workshops_conferences_id, email) VALUES (?, ?)`, [params.id, email])
-            }
-          }
-          return NextResponse.json(workshopResult)
+    //     case 'workshops_conferences':
+    //       const workshopResult = await query(
+    //         `UPDATE workshops_conferences SET 
+    //          event_type = ?,
+    //          role = ?,
+    //          event_name = ?,
+    //          sponsored_by = ?,
+    //          start_date = ?,
+    //          end_date = ?,
+    //          participants_count = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.event_type,
+    //           params.role,
+    //           params.event_name,
+    //           params.sponsored_by,
+    //           params.start_date,
+    //           params.end_date,
+    //           params.participants_count,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
+    //         try { await query(`DELETE FROM workshops_conferences_collaborater WHERE workshops_conferences_id = ?`, [params.id]) } catch (e) {}
+    //         for (const email of params.collaboraters) {
+    //           await query(`INSERT INTO workshops_conferences_collaborater(workshops_conferences_id, email) VALUES (?, ?)`, [params.id, email])
+    //         }
+    //       }
+    //       return NextResponse.json(workshopResult)
 
-        case 'institute_activities':
-          const instituteResult = await query(
-            `UPDATE institute_activities SET 
-             role_position = ?,
-             institute_name = ?,
-             start_date = ?,
-             end_date = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.role_position,
-              params.institute_name,
-              params.start_date,
-              params.end_date,
-              params.id,
-              params.email
-            ]
-          )
-          return NextResponse.json(instituteResult)
+    //     case 'institute_activities':
+    //       const instituteResult = await query(
+    //         `UPDATE institute_activities SET 
+    //          role_position = ?,
+    //          institute_name = ?,
+    //          start_date = ?,
+    //          end_date = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.role_position,
+    //           params.institute_name,
+    //           params.start_date,
+    //           params.end_date,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       return NextResponse.json(instituteResult)
 
-        case 'department_activities':
-          const departmentResult = await query(
-            `UPDATE department_activities SET 
-             activity_description = ?,
-             institute_name = ?,
-             start_date = ?,
-             end_date = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.activity_description,
-              params.institute_name,
-              params.start_date,
-              params.end_date,
-              params.id,
-              params.email
-            ]
-          )
-          return NextResponse.json(departmentResult)
+    //     case 'department_activities':
+    //       const departmentResult = await query(
+    //         `UPDATE department_activities SET 
+    //          activity_description = ?,
+    //          institute_name = ?,
+    //          start_date = ?,
+    //          end_date = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.activity_description,
+    //           params.institute_name,
+    //           params.start_date,
+    //           params.end_date,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       return NextResponse.json(departmentResult)
 
-        case 'internships':
-          const internshipResult = await query(
-            `UPDATE internships SET 
-             student_name = ?,
-             qualification = ?,
-             affiliation = ?,
-             project_title = ?,
-             start_date = ?,
-             end_date = ?,
-             student_type = ?
-             WHERE id = ? AND email = ?`,
-            [
-              params.student_name,
-              params.qualification,
-              params.affiliation,
-              params.project_title,
-              params.start_date,
-              params.end_date,
-              params.student_type,
-              params.id,
-              params.email
-            ]
-          )
-          return NextResponse.json(internshipResult)
+    //     case 'internships':
+    //       const internshipResult = await query(
+    //         `UPDATE internships SET 
+    //          student_name = ?,
+    //          qualification = ?,
+    //          affiliation = ?,
+    //          project_title = ?,
+    //          start_date = ?,
+    //          end_date = ?,
+    //          student_type = ?
+    //          WHERE id = ? AND email = ?`,
+    //         [
+    //           params.student_name,
+    //           params.qualification,
+    //           params.affiliation,
+    //           params.project_title,
+    //           params.start_date,
+    //           params.end_date,
+    //           params.student_type,
+    //           params.id,
+    //           params.email
+    //         ]
+    //       )
+    //       return NextResponse.json(internshipResult)
 
-        case 'education':
-          const educationResult = await query(
-            `UPDATE education SET 
-             certification = ?,
-             institution = ?,
-             passing_year = ?,
-             specialization=?
-             WHERE id = ? AND email = ?`,
-            [params.certification, params.institution, params.passing_year,params.specialization, params.id, params.email]
-          )
-          return NextResponse.json(educationResult)
-      }
-    }
+    //     case 'education':
+    //       const educationResult = await query(
+    //         `UPDATE education SET 
+    //          certification = ?,
+    //          institution = ?,
+    //          passing_year = ?,
+    //          specialization=?
+    //          WHERE id = ? AND email = ?`,
+    //         [params.certification, params.institution, params.passing_year,params.specialization, params.id, params.email]
+    //       )
+    //       return NextResponse.json(educationResult)
+    //   }
+    // }
+    // uncomment it
 
     return NextResponse.json(
       { message: 'Could not find matching requests' },

--- a/src/app/api/update/route.js
+++ b/src/app/api/update/route.js
@@ -6,67 +6,65 @@ import { authOptions } from '@/lib/authOptions'
 export async function PUT(request) {
   try {
     // Use original authentication for now
-    // const session = await getServerSession(authOptions)
+    const session = await getServerSession(authOptions)
     
-    // if (!session) {
-    //   return NextResponse.json(
-    //     { message: 'Not authenticated' },
-    //     { status: 401 }
-    //   )
-    // }
+    if (!session) {
+      return NextResponse.json(
+        { message: 'Not authenticated' },
+        { status: 401 }
+      )
+    }
 
     const { type, ...params } = await request.json()
-    // uncomment it
+    
 
     // Handle profile updates
-    // if (type === 'profile') {
-    //   // Check permissions
-    //   if (session.user.email !== params.email && session.user.role !== 'SUPER_ADMIN') {
-    //     return NextResponse.json(
-    //       { message: 'Not authorized' },
-    //       { status: 403 }
-    //     )
-    //   }
+    if (type === 'profile') {
+      // Check permissions
+      if (session.user.email !== params.email && session.user.role !== 'SUPER_ADMIN') {
+        return NextResponse.json(
+          { message: 'Not authorized' },
+          { status: 403 }
+        )
+      }
 
-    //   let queryParts = []
-    //   let updateValues = []
+      let queryParts = []
+      let updateValues = []
 
-    //   // Handle all possible profile fields
-    //   const fields = [
-    //       'image',
-    //       'cv',
-    //       'name',
-    //       'designation',
-    //       'research_interest',
-    //       'academic_responsibility',
-    //       'ext_no',
-    //       'linkedin',
-    //       'google_scholar',
-    //       'personal_webpage',
-    //       'scopus',
-    //       'vidwan',
-    //       'orcid'
-    //   ]
+      // Handle all possible profile fields
+      const fields = [
+          'image',
+          'cv',
+          'name',
+          'designation',
+          'research_interest',
+          'academic_responsibility',
+          'ext_no',
+          'linkedin',
+          'google_scholar',
+          'personal_webpage',
+          'scopus',
+          'vidwan',
+          'orcid'
+      ]
 
-    //   fields.forEach(field => {
-    //       if (params[field] !== undefined) {
-    //           queryParts.push(`${field} = ?`)
-    //           updateValues.push(params[field])
-    //       }
-    //   })
+      fields.forEach(field => {
+          if (params[field] !== undefined) {
+              queryParts.push(`${field} = ?`)
+              updateValues.push(params[field])
+          }
+      })
 
-    //   // Add email as the last parameter
-    //   updateValues.push(params.email)
+      // Add email as the last parameter
+      updateValues.push(params.email)
 
-    //   const result = await query(
-    //       `UPDATE user SET ${queryParts.join(', ')} WHERE email = ?`,
-    //       updateValues
-    //   )
+      const result = await query(
+          `UPDATE user SET ${queryParts.join(', ')} WHERE email = ?`,
+          updateValues
+      )
 
-    //   return NextResponse.json(result)
-    // }
-    // uncomment it
-
+      return NextResponse.json(result)
+    }
     // Notice updates - Super Admin, Academic Admin, and Department Admin access
     if (type === 'notice') {
       // First, get the notice details to check authorization
@@ -83,31 +81,29 @@ export async function PUT(request) {
       }
 
       const noticeData = notice[0];
-    // uncomment it
       
-      // console.log('DEBUG: Notice update authorization check')
-      // console.log('User role:', session.user.role)
-      // console.log('User department:', session.user.department)
-      // console.log('Notice department:', noticeData.department)
-      // console.log('Notice type:', noticeData.notice_type)
+      console.log('DEBUG: Notice update authorization check')
+      console.log('User role:', session.user.role)
+      console.log('User department:', session.user.department)
+      console.log('Notice department:', noticeData.department)
+      console.log('Notice type:', noticeData.notice_type)
   
 
-      // const canUpdateNotice = 
-      //   session.user.role === 'SUPER_ADMIN' ||
-      //   (session.user.role === 'ACADEMIC_ADMIN' && noticeData.notice_type === 'academics') ||
-      //   (session.user.role === 'DEPT_ADMIN' && 
-      //    noticeData.notice_type === 'department' && 
-      //    noticeData.department === session.user.department)
+      const canUpdateNotice = 
+        session.user.role === 'SUPER_ADMIN' ||
+        (session.user.role === 'ACADEMIC_ADMIN' && noticeData.notice_type === 'academics') ||
+        (session.user.role === 'DEPT_ADMIN' && 
+         noticeData.notice_type === 'department' && 
+         noticeData.department === session.user.department)
       
-      // console.log('Can update notice:', canUpdateNotice)
+      console.log('Can update notice:', canUpdateNotice)
       
-      // if (!canUpdateNotice) {
-      //   return NextResponse.json(
-      //     { message: 'Not authorized to update notices' },
-      //     { status: 403 }
-      //   )
-      // }
-    // uncomment it
+      if (!canUpdateNotice) {
+        return NextResponse.json(
+          { message: 'Not authorized to update notices' },
+          { status: 403 }
+        )
+      }
 
 
       // Log any attachments for debugging
@@ -128,12 +124,11 @@ export async function PUT(request) {
             attachments = ?,
             notice_link = ?,
             isVisible = ?,
-            
+            updatedBy = ?
             notice_type = ?,
             notice_sub_type = ?,
             department = ?
         WHERE id = ?`,
-        // add updatedBy = ?, in query
         [
             params.data.title,
             new Date().getTime(),
@@ -143,7 +138,7 @@ export async function PUT(request) {
             JSON.stringify(params.data.attachments),
             params.data.notice_link || null,
             params.data.isVisible === undefined ? 1 : Number(params.data.isVisible),
-            // session.user.email,
+            session.user.email,
             params.data.notice_type || null,
             params.data.notice_sub_type || null,
             params.data.department || null,
@@ -154,814 +149,811 @@ export async function PUT(request) {
     }
 
     // Super Admin only access
-    // uncomment it
-    // if (session.user.role === 'SUPER_ADMIN') {
-    //   switch (type) {
-    //     case 'event':
-    //       const eventResult = await query(
-    //         `UPDATE events SET 
-    //          title = ?,
-    //          updatedAt = ?,
-    //          openDate = ?,
-    //          closeDate = ?,
-    //          venue = ?,
-    //          doclink = ?,
-    //          attachments = ?,
-    //          event_link = ?,
-    //          eventStartDate = ?,
-    //          eventEndDate = ?,
-    //          updatedBy = ?,
-    //          type = ?
-    //          WHERE id = ?`,
-    //         [
-    //           params.data.title,
-    //           new Date().getTime(),
-    //           params.data.openDate,
-    //           params.data.closeDate,
-    //           params.data.venue,
-    //           params.data.doclink,
-    //           JSON.stringify(params.data.attachments || []),
-    //           JSON.stringify(params.data.event_link),
-    //           params.data.eventStartDate,
-    //           params.data.eventEndDate,
-    //           params.data.updatedBy || session.user.email,
-    //           params.data.type || 'general',
-    //           params.data.id
-    //         ]
-    //       )
-    //       return NextResponse.json(eventResult)
+    if (session.user.role === 'SUPER_ADMIN') {
+      switch (type) {
+        case 'event':
+          const eventResult = await query(
+            `UPDATE events SET 
+             title = ?,
+             updatedAt = ?,
+             openDate = ?,
+             closeDate = ?,
+             venue = ?,
+             doclink = ?,
+             attachments = ?,
+             event_link = ?,
+             eventStartDate = ?,
+             eventEndDate = ?,
+             updatedBy = ?,
+             type = ?
+             WHERE id = ?`,
+            [
+              params.data.title,
+              new Date().getTime(),
+              params.data.openDate,
+              params.data.closeDate,
+              params.data.venue,
+              params.data.doclink,
+              JSON.stringify(params.data.attachments || []),
+              JSON.stringify(params.data.event_link),
+              params.data.eventStartDate,
+              params.data.eventEndDate,
+              params.data.updatedBy || session.user.email,
+              params.data.type || 'general',
+              params.data.id
+            ]
+          )
+          return NextResponse.json(eventResult)
 
-    //     case 'patents':
-    //       const patentResult = await query(
-    //           `UPDATE patents
-    //           SET title = ?, description = ?, patent_date = ?, email = ?
-    //           WHERE id = ?`,
-    //           [
-    //               params.title,
-    //               params.description,
-    //               params.patent_date,
-    //               params.email,
-    //               params.id 
-    //           ]
-    //       );
-    //       return NextResponse.json(patentResult);
+        case 'patents':
+          const patentResult = await query(
+              `UPDATE patents
+              SET title = ?, description = ?, patent_date = ?, email = ?
+              WHERE id = ?`,
+              [
+                  params.title,
+                  params.description,
+                  params.patent_date,
+                  params.email,
+                  params.id 
+              ]
+          );
+          return NextResponse.json(patentResult);
 
-    //     case 'innovation':
-    //       const innovationResult = await query(
-    //         `UPDATE innovation SET 
-    //          title = ?,
-    //          updatedAt = ?,
-    //          openDate = ?,
-    //          closeDate = ?,
-    //          description = ?,
-    //          image = ?,
-    //          author = ?,
-    //          updatedBy = ?
-    //          WHERE id = ?`,
-    //         [
-    //           params.data.title,
-    //           new Date().getTime(),
-    //           params.data.openDate,
-    //           params.data.closeDate,
-    //           params.data.description,
-    //           JSON.stringify(params.data.image),
-    //           params.data.author,
-    //           params.data.email,
-    //           params.data.id
-    //         ]
-    //       )
-    //       return NextResponse.json(innovationResult)
+        case 'innovation':
+          const innovationResult = await query(
+            `UPDATE innovation SET 
+             title = ?,
+             updatedAt = ?,
+             openDate = ?,
+             closeDate = ?,
+             description = ?,
+             image = ?,
+             author = ?,
+             updatedBy = ?
+             WHERE id = ?`,
+            [
+              params.data.title,
+              new Date().getTime(),
+              params.data.openDate,
+              params.data.closeDate,
+              params.data.description,
+              JSON.stringify(params.data.image),
+              params.data.author,
+              params.data.email,
+              params.data.id
+            ]
+          )
+          return NextResponse.json(innovationResult)
 
-    //     case 'news':
-    //       const newsResult = await query(
-    //         `UPDATE news SET 
-    //          title = ?,
-    //          updatedAt = ?,
-    //          openDate = ?,
-    //          closeDate = ?,
-    //          image = ?,
-    //          description = ?,
-    //          attachments = ?,
-    //          author = ?,
-    //          updatedBy = ?
-    //          WHERE id = ?`,
-    //         [
-    //           params.data.title,
-    //           new Date().getTime(),
-    //           params.data.openDate,
-    //           params.data.closeDate,
-    //           JSON.stringify(params.data.image),
-    //           params.data.description,
-    //           JSON.stringify(params.data.add_attach),
-    //           params.data.author,
-    //           params.data.email,
-    //           params.data.id
-    //         ]
-    //       )
-    //       return NextResponse.json(newsResult)
+        case 'news':
+          const newsResult = await query(
+            `UPDATE news SET 
+             title = ?,
+             updatedAt = ?,
+             openDate = ?,
+             closeDate = ?,
+             image = ?,
+             description = ?,
+             attachments = ?,
+             author = ?,
+             updatedBy = ?
+             WHERE id = ?`,
+            [
+              params.data.title,
+              new Date().getTime(),
+              params.data.openDate,
+              params.data.closeDate,
+              JSON.stringify(params.data.image),
+              params.data.description,
+              JSON.stringify(params.data.add_attach),
+              params.data.author,
+              params.data.email,
+              params.data.id
+            ]
+          )
+          return NextResponse.json(newsResult)
 
-    //     case 'user':
-    //       if (params.update_social_media_links) {
-    //         const socialResult = await query(
-    //           `UPDATE user SET 
-    //            linkedin = ?,
-    //            google_scholar = ?,
-    //            personal_webpage = ?,
-    //            scopus = ?,
-    //            vidwan = ?,
-    //            orcid = ?
-    //            WHERE email = ?`,
-    //           [
-    //             params.Linkedin || '',
-    //             params['Google Scholar'] || '',
-    //             params['Personal Webpage'] || '',
-    //             params['Scopus'] || '',
-    //             params['Vidwan'] || '',
-    //             params['Orcid'] || '',
-    //             session.user.email
-    //           ]
-    //         )
-    //         return NextResponse.json(socialResult)
-    //       } else {
-    //         const {
-    //           email,
-    //           name,
-    //           department,
-    //           designation,
-    //           role,
-    //           ext_no,
-    //           research_interest,
-    //           academic_responsibility,
-    //           is_retired,
-    //           retirement_date
-    //         } = params
+        case 'user':
+          if (params.update_social_media_links) {
+            const socialResult = await query(
+              `UPDATE user SET 
+               linkedin = ?,
+               google_scholar = ?,
+               personal_webpage = ?,
+               scopus = ?,
+               vidwan = ?,
+               orcid = ?
+               WHERE email = ?`,
+              [
+                params.Linkedin || '',
+                params['Google Scholar'] || '',
+                params['Personal Webpage'] || '',
+                params['Scopus'] || '',
+                params['Vidwan'] || '',
+                params['Orcid'] || '',
+                session.user.email
+              ]
+            )
+            return NextResponse.json(socialResult)
+          } else {
+            const {
+              email,
+              name,
+              department,
+              designation,
+              role,
+              ext_no,
+              research_interest,
+              academic_responsibility,
+              is_retired,
+              retirement_date
+            } = params
 
-    //         // Format retirement_date for MySQL or set to NULL
-    //         const formattedRetirementDate = retirement_date ? new Date(retirement_date).toISOString().slice(0, 10) : null
+            // Format retirement_date for MySQL or set to NULL
+            const formattedRetirementDate = retirement_date ? new Date(retirement_date).toISOString().slice(0, 10) : null
 
-    //         const facultyResult = await query(
-    //           `UPDATE user SET 
-    //             name = ?,
-    //             department = ?,
-    //             designation = ?,
-    //             role = ?,
-    //             ext_no = ?,
-    //             research_interest = ?,
-    //             academic_responsibility = ?,
-    //             is_retired = ?,
-    //             retirement_date = ?
-    //           WHERE email = ?`,
-    //           [
-    //             name,
-    //             department,
-    //             designation,
-    //             role,
-    //             ext_no,
-    //             research_interest,
-    //             academic_responsibility || null,
-    //             is_retired,
-    //             formattedRetirementDate,
-    //             email
-    //           ]
-    //         )
-    //         return NextResponse.json(facultyResult)
-    //       }
-    //   }
-    // }
+            const facultyResult = await query(
+              `UPDATE user SET 
+                name = ?,
+                department = ?,
+                designation = ?,
+                role = ?,
+                ext_no = ?,
+                research_interest = ?,
+                academic_responsibility = ?,
+                is_retired = ?,
+                retirement_date = ?
+              WHERE email = ?`,
+              [
+                name,
+                department,
+                designation,
+                role,
+                ext_no,
+                research_interest,
+                academic_responsibility || null,
+                is_retired,
+                formattedRetirementDate,
+                email
+              ]
+            )
+            return NextResponse.json(facultyResult)
+          }
+      }
+    }
 
-    // // User specific updates (email matches)
-    // if (session.user.email === params.email) {
-    //   switch (type) {
-    //     // Academic Records
-    //     case 'phd_candidates':
-    //       const phdResult = await query(
-    //         `UPDATE phd_candidates SET 
-    //           student_name = ?,
-    //           roll_no = ?,
-    //           registration_year = ?,
-    //           registration_type = ?,
-    //           research_area = ?,
-    //           other_supervisors = ?,
-    //           current_status = ?,
-    //           completion_year = ?,
-    //           supervisor_type = ? ,
-    //           registration_date = ?
-    //         WHERE id = ? AND email = ?`,
-    //         [
-    //           params.student_name,
-    //           params.roll_no,
-    //           new Date(params.registration_date).getFullYear(),
-    //           params.registration_type,
-    //           params.research_area,
-    //           params.other_supervisors,
-    //           params.current_status,
-    //           params.completion_year,
-    //           params.supervisor_type,
-    //           params.registration_date,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       ); 
-    //       return NextResponse.json(phdResult)
+    // User specific updates (email matches)
+    if (session.user.email === params.email) {
+      switch (type) {
+        // Academic Records
+        case 'phd_candidates':
+          const phdResult = await query(
+            `UPDATE phd_candidates SET 
+              student_name = ?,
+              roll_no = ?,
+              registration_year = ?,
+              registration_type = ?,
+              research_area = ?,
+              other_supervisors = ?,
+              current_status = ?,
+              completion_year = ?,
+              supervisor_type = ? ,
+              registration_date = ?
+            WHERE id = ? AND email = ?`,
+            [
+              params.student_name,
+              params.roll_no,
+              new Date(params.registration_date).getFullYear(),
+              params.registration_type,
+              params.research_area,
+              params.other_supervisors,
+              params.current_status,
+              params.completion_year,
+              params.supervisor_type,
+              params.registration_date,
+              params.id,
+              params.email
+            ]
+          ); 
+          return NextResponse.json(phdResult)
 
-    //     case 'journal_papers': {
-    //         try {
-    //           const journalResult = await query(
-    //             `UPDATE journal_papers SET 
-    //                 authors = ?,
-    //                 title = ?,
-    //                 journal_name = ?,
-    //                 volume = ?,
-    //                 publication_year = ?,
-    //                 pages = ?,
-    //                 journal_quartile = ?,
-    //                 publication_date = ?,
-    //                 student_involved = ?,
-    //                 student_details = ?,
-    //                 doi_url = ?,
-    //                 indexing = ?,
-    //                 foreign_author_details = ?,
-    //                 nationality_type = ?
-    //             WHERE id = ? AND email = ?`,
-    //             [
-    //               params.authors,
-    //               params.title,
-    //               params.journal_name,
-    //               params.volume,
-    //               params.publication_year,
-    //               params.pages,
-    //               params.journal_quartile,
-    //               params.publication_date,
-    //               params.student_involved,
-    //               params.student_details,
-    //               params.doi_url,
-    //               params.indexing,
-    //               params.foreign_author_details,
-    //               params.nationality_type,
-    //               params.id,
-    //               params.email
-    //             ]
-    //           );
+        case 'journal_papers': {
+            try {
+              const journalResult = await query(
+                `UPDATE journal_papers SET 
+                    authors = ?,
+                    title = ?,
+                    journal_name = ?,
+                    volume = ?,
+                    publication_year = ?,
+                    pages = ?,
+                    journal_quartile = ?,
+                    publication_date = ?,
+                    student_involved = ?,
+                    student_details = ?,
+                    doi_url = ?,
+                    indexing = ?,
+                    foreign_author_details = ?,
+                    nationality_type = ?
+                WHERE id = ? AND email = ?`,
+                [
+                  params.authors,
+                  params.title,
+                  params.journal_name,
+                  params.volume,
+                  params.publication_year,
+                  params.pages,
+                  params.journal_quartile,
+                  params.publication_date,
+                  params.student_involved,
+                  params.student_details,
+                  params.doi_url,
+                  params.indexing,
+                  params.foreign_author_details,
+                  params.nationality_type,
+                  params.id,
+                  params.email
+                ]
+              );
 
-    //           if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //             const existingRows = await query(
-    //               `SELECT email FROM journal_paper_collaborater WHERE journal_paper_id = ?`,
-    //               [params.id]
-    //             );
-    //             const existingEmails = existingRows.map(row => row.email);
+              if (params.collaboraters && Array.isArray(params.collaboraters)) {
+                const existingRows = await query(
+                  `SELECT email FROM journal_paper_collaborater WHERE journal_paper_id = ?`,
+                  [params.id]
+                );
+                const existingEmails = existingRows.map(row => row.email);
 
-    //             const newEmails = params.collaboraters.filter(e => !existingEmails.includes(e));
-    //             const removedEmails = existingEmails.filter(e => !params.collaboraters.includes(e));
+                const newEmails = params.collaboraters.filter(e => !existingEmails.includes(e));
+                const removedEmails = existingEmails.filter(e => !params.collaboraters.includes(e));
 
-    //             for (const email of newEmails) {
-    //               await query(
-    //                 `INSERT INTO journal_paper_collaborater (journal_paper_id, email)
-    //                 VALUES (?, ?)`,
-    //                 [params.id, email]
-    //               );
-    //             }
+                for (const email of newEmails) {
+                  await query(
+                    `INSERT INTO journal_paper_collaborater (journal_paper_id, email)
+                    VALUES (?, ?)`,
+                    [params.id, email]
+                  );
+                }
 
-    //             for (const email of removedEmails) {
-    //               await query(
-    //                 `DELETE FROM journal_paper_collaborater 
-    //                 WHERE journal_paper_id = ? AND email = ?`,
-    //                 [params.id, email]
-    //               );
-    //             }
-    //           }
+                for (const email of removedEmails) {
+                  await query(
+                    `DELETE FROM journal_paper_collaborater 
+                    WHERE journal_paper_id = ? AND email = ?`,
+                    [params.id, email]
+                  );
+                }
+              }
 
-    //           const papersWithCollaborators = await query(
-    //             `SELECT jp.*, 
-    //                     GROUP_CONCAT(jpc.email) AS collaboraters
-    //             FROM journal_papers jp
-    //             LEFT JOIN journal_paper_collaborater jpc
-    //             ON jp.id = jpc.journal_paper_id
-    //             WHERE jp.id = ?
-    //             GROUP BY jp.id
-    //             ORDER BY jp.publication_year DESC`,
-    //             [params.id]
-    //           );
+              const papersWithCollaborators = await query(
+                `SELECT jp.*, 
+                        GROUP_CONCAT(jpc.email) AS collaboraters
+                FROM journal_papers jp
+                LEFT JOIN journal_paper_collaborater jpc
+                ON jp.id = jpc.journal_paper_id
+                WHERE jp.id = ?
+                GROUP BY jp.id
+                ORDER BY jp.publication_year DESC`,
+                [params.id]
+              );
 
-    //           return NextResponse.json({
-    //             success: true,
-    //             message: 'Journal paper and collaborators updated successfully',
-    //             data: papersWithCollaborators[0] || {}
-    //           });
+              return NextResponse.json({
+                success: true,
+                message: 'Journal paper and collaborators updated successfully',
+                data: papersWithCollaborators[0] || {}
+              });
 
-    //         } catch (error) {
-    //           console.error('[Journal Paper Update Error]:', error);
-    //           return NextResponse.json(
-    //             { success: false, error: error.message },
-    //             { status: 500 }
-    //           );
-    //         }
-    //       }
+            } catch (error) {
+              console.error('[Journal Paper Update Error]:', error);
+              return NextResponse.json(
+                { success: false, error: error.message },
+                { status: 500 }
+              );
+            }
+          }
 
-    //     case 'conference_papers':
-    //       const conferenceResult = await query(
-    //         `UPDATE conference_papers SET 
-    //           authors = ?,
-    //           title = ?,
-    //           conference_name = ?,
-    //           location = ?,
-    //           conference_year = ?,
-    //           conference_type = ?,
-    //           student_name = ?,
-    //           student_roll_no = ?,
-    //           foreign_author_name = ?,
-    //           foreign_author_country_name = ?,
-    //           foreign_author_institute_name = ?,
-    //           pages = ?,
-    //           indexing = ?,
-    //           foreign_author = ?,
-    //           student_involved = ?,
-    //           doi = ?
-    //         WHERE id = ? AND email = ?`,
-    //         [
-    //           params.authors,
-    //           params.title,
-    //           params.conference_name,
-    //           params.location,
-    //           params.conference_year,
-    //           params.conference_type,
-    //           params.student_name,
-    //           params.student_roll_no,
-    //           params.foreign_author_name,
-    //           params.foreign_author_country_name,
-    //           params.foreign_author_institute_name,
-    //           params.pages,
-    //           params.indexing,
-    //           params.foreign_author_name ? "yes" : "no",
-    //           params.student_name ? "yes" : "no",
-    //           params.doi,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
+        case 'conference_papers':
+          const conferenceResult = await query(
+            `UPDATE conference_papers SET 
+              authors = ?,
+              title = ?,
+              conference_name = ?,
+              location = ?,
+              conference_year = ?,
+              conference_type = ?,
+              student_name = ?,
+              student_roll_no = ?,
+              foreign_author_name = ?,
+              foreign_author_country_name = ?,
+              foreign_author_institute_name = ?,
+              pages = ?,
+              indexing = ?,
+              foreign_author = ?,
+              student_involved = ?,
+              doi = ?
+            WHERE id = ? AND email = ?`,
+            [
+              params.authors,
+              params.title,
+              params.conference_name,
+              params.location,
+              params.conference_year,
+              params.conference_type,
+              params.student_name,
+              params.student_roll_no,
+              params.foreign_author_name,
+              params.foreign_author_country_name,
+              params.foreign_author_institute_name,
+              params.pages,
+              params.indexing,
+              params.foreign_author_name ? "yes" : "no",
+              params.student_name ? "yes" : "no",
+              params.doi,
+              params.id,
+              params.email
+            ]
+          )
 
-    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //         try { 
-    //           await query(`DELETE FROM conference_papers_collaborater WHERE conference_papers_id = ?`, [params.id]) 
-    //         } catch (e) {}
+          if (params.collaboraters && Array.isArray(params.collaboraters)) {
+            try { 
+              await query(`DELETE FROM conference_papers_collaborater WHERE conference_papers_id = ?`, [params.id]) 
+            } catch (e) {}
             
-    //         for (const email of params.collaboraters) {
-    //           await query(
-    //             `INSERT INTO conference_papers_collaborater(conference_papers_id, email) VALUES (?, ?)`,
-    //             [params.id, email]
-    //           )
-    //         }
-    //       }
+            for (const email of params.collaboraters) {
+              await query(
+                `INSERT INTO conference_papers_collaborater(conference_papers_id, email) VALUES (?, ?)`,
+                [params.id, email]
+              )
+            }
+          }
 
-    //       const conferencesWithCollaborators = await query(
-    //         `SELECT cp.*, GROUP_CONCAT(cpc.email) AS collaboraters
-    //          FROM conference_papers cp
-    //          LEFT JOIN conference_papers_collaborater cpc
-    //            ON cp.id = cpc.conference_papers_id
-    //          WHERE cp.id = ?
-    //          GROUP BY cp.id`,
-    //         [params.id]
-    //       )
+          const conferencesWithCollaborators = await query(
+            `SELECT cp.*, GROUP_CONCAT(cpc.email) AS collaboraters
+             FROM conference_papers cp
+             LEFT JOIN conference_papers_collaborater cpc
+               ON cp.id = cpc.conference_papers_id
+             WHERE cp.id = ?
+             GROUP BY cp.id`,
+            [params.id]
+          )
 
-    //       return NextResponse.json({ conference: conferencesWithCollaborators[0] || null })
+          return NextResponse.json({ conference: conferencesWithCollaborators[0] || null })
 
 
-    //     // Books
-    //     case 'textbooks':
-    //       const textbookResult = await query(
-    //         `UPDATE textbooks SET 
-    //          title = ?,
-    //          authors = ?,
-    //          publisher = ?,
-    //          isbn = ?,
-    //          year = ?,
-    //          scopus = ?,
-    //          doi = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.title,
-    //           params.authors,
-    //           params.publisher,
-    //           params.isbn,
-    //           params.year,
-    //           params.scopus,
-    //           params.doi,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //         try { await query(`DELETE FROM textbooks_collaborater WHERE textbooks_id = ?`, [params.id]) } catch (e) {}
-    //         for (const email of params.collaboraters) {
-    //           await query(`INSERT INTO textbooks_collaborater(textbooks_id, email) VALUES (?, ?)`, [params.id, email])
-    //         }
-    //       }
-    //       return NextResponse.json(textbookResult)
+        // Books
+        case 'textbooks':
+          const textbookResult = await query(
+            `UPDATE textbooks SET 
+             title = ?,
+             authors = ?,
+             publisher = ?,
+             isbn = ?,
+             year = ?,
+             scopus = ?,
+             doi = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.title,
+              params.authors,
+              params.publisher,
+              params.isbn,
+              params.year,
+              params.scopus,
+              params.doi,
+              params.id,
+              params.email
+            ]
+          )
+          if (params.collaboraters && Array.isArray(params.collaboraters)) {
+            try { await query(`DELETE FROM textbooks_collaborater WHERE textbooks_id = ?`, [params.id]) } catch (e) {}
+            for (const email of params.collaboraters) {
+              await query(`INSERT INTO textbooks_collaborater(textbooks_id, email) VALUES (?, ?)`, [params.id, email])
+            }
+          }
+          return NextResponse.json(textbookResult)
 
-    //     case 'edited_books':
-    //       const editedBookResult = await query(
-    //         `UPDATE edited_books SET 
-    //          title = ?,
-    //          editors = ?,
-    //          publisher = ?,
-    //          isbn = ?,
-    //          year = ?,
-    //          scopus = ?,
-    //          doi = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.title,
-    //           params.editors,
-    //           params.publisher,
-    //           params.isbn,
-    //           params.year,
-    //           params.scopus,
-    //           params.doi,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //         try { await query(`DELETE FROM edited_books_collaborater WHERE edited_books_id = ?`, [params.id]) } catch (e) {}
-    //         for (const email of params.collaboraters) {
-    //           await query(`INSERT INTO edited_books_collaborater(edited_books_id, email) VALUES (?, ?)`, [params.id, email])
-    //         }
-    //       }
-    //       const updatedEditedBooks = await query(
-    //         `SELECT eb.*, GROUP_CONCAT(ebc.email) AS collaboraters
-    //          FROM edited_books eb
-    //          LEFT JOIN edited_books_collaborater ebc
-    //            ON eb.id = ebc.edited_books_id
-    //          WHERE eb.id = ?
-    //          GROUP BY eb.id`,
-    //         [params.id]
-    //       )
+        case 'edited_books':
+          const editedBookResult = await query(
+            `UPDATE edited_books SET 
+             title = ?,
+             editors = ?,
+             publisher = ?,
+             isbn = ?,
+             year = ?,
+             scopus = ?,
+             doi = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.title,
+              params.editors,
+              params.publisher,
+              params.isbn,
+              params.year,
+              params.scopus,
+              params.doi,
+              params.id,
+              params.email
+            ]
+          )
+          if (params.collaboraters && Array.isArray(params.collaboraters)) {
+            try { await query(`DELETE FROM edited_books_collaborater WHERE edited_books_id = ?`, [params.id]) } catch (e) {}
+            for (const email of params.collaboraters) {
+              await query(`INSERT INTO edited_books_collaborater(edited_books_id, email) VALUES (?, ?)`, [params.id, email])
+            }
+          }
+          const updatedEditedBooks = await query(
+            `SELECT eb.*, GROUP_CONCAT(ebc.email) AS collaboraters
+             FROM edited_books eb
+             LEFT JOIN edited_books_collaborater ebc
+               ON eb.id = ebc.edited_books_id
+             WHERE eb.id = ?
+             GROUP BY eb.id`,
+            [params.id]
+          )
 
-    //       return NextResponse.json({ editedBook: updatedEditedBooks[0] || null })
+          return NextResponse.json({ editedBook: updatedEditedBooks[0] || null })
 
-    //     case 'book_chapters':
-    //       const chapterResult = await query(
-    //         `UPDATE book_chapters SET 
-    //          authors = ?,
-    //          chapter_title = ?,
-    //          book_title = ?,
-    //          pages = ?,
-    //          publisher = ?,
-    //          isbn = ?,
-    //          year = ?,
-    //          scopus = ?,
-    //          doi = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.authors,
-    //           params.chapter_title,
-    //           params.book_title,
-    //           params.pages,
-    //           params.publisher,
-    //           params.isbn,
-    //           params.year,
-    //           params.scopus,
-    //           params.doi,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //         try { await query(`DELETE FROM book_chapters_collaborater WHERE book_chapters_id = ?`, [params.id]) } catch (e) {}
-    //         for (const email of params.collaboraters) {
-    //           await query(`INSERT INTO book_chapters_collaborater(book_chapters_id, email) VALUES (?, ?)`, [params.id, email])
-    //         }
-    //       }
-    //       return NextResponse.json(chapterResult)
+        case 'book_chapters':
+          const chapterResult = await query(
+            `UPDATE book_chapters SET 
+             authors = ?,
+             chapter_title = ?,
+             book_title = ?,
+             pages = ?,
+             publisher = ?,
+             isbn = ?,
+             year = ?,
+             scopus = ?,
+             doi = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.authors,
+              params.chapter_title,
+              params.book_title,
+              params.pages,
+              params.publisher,
+              params.isbn,
+              params.year,
+              params.scopus,
+              params.doi,
+              params.id,
+              params.email
+            ]
+          )
+          if (params.collaboraters && Array.isArray(params.collaboraters)) {
+            try { await query(`DELETE FROM book_chapters_collaborater WHERE book_chapters_id = ?`, [params.id]) } catch (e) {}
+            for (const email of params.collaboraters) {
+              await query(`INSERT INTO book_chapters_collaborater(book_chapters_id, email) VALUES (?, ?)`, [params.id, email])
+            }
+          }
+          return NextResponse.json(chapterResult)
 
-    //     // Projects
-    //     case 'sponsored_projects':
-    //       const sponsoredResult = await query(
-    //         `UPDATE sponsored_projects SET 
-    //          project_title = ?,
-    //          role=?,
-    //          funding_agency = ?,
-    //          financial_outlay = ?,
-    //          start_date = ?,
-    //          end_date = ?,
-    //          investigators = ?,
-    //          pi_institute = ?,
-    //          status = ?,
-    //          funds_received = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.project_title,
-    //           params.role,
-    //           params.funding_agency,
-    //           params.financial_outlay,
-    //           params.start_date,
-    //           params.end_date,
-    //           params.investigators,
-    //           params.pi_institute,
-    //           params.status,
-    //           params.funds_received,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //         try {
-    //           await query(`DELETE FROM sponsored_projects_collaborater WHERE sponsored_project_id = ?`, [params.id])
-    //         } catch (e) {}
-    //         for (const email of params.collaboraters) {
-    //           await query(
-    //             `INSERT INTO sponsored_projects_collaborater(sponsored_project_id, email) VALUES (?, ?)`,
-    //             [params.id, email]
-    //           )
-    //         }
-    //       }
-    //       return NextResponse.json(sponsoredResult)
+        // Projects
+        case 'sponsored_projects':
+          const sponsoredResult = await query(
+            `UPDATE sponsored_projects SET 
+             project_title = ?,
+             role=?,
+             funding_agency = ?,
+             financial_outlay = ?,
+             start_date = ?,
+             end_date = ?,
+             investigators = ?,
+             pi_institute = ?,
+             status = ?,
+             funds_received = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.project_title,
+              params.role,
+              params.funding_agency,
+              params.financial_outlay,
+              params.start_date,
+              params.end_date,
+              params.investigators,
+              params.pi_institute,
+              params.status,
+              params.funds_received,
+              params.id,
+              params.email
+            ]
+          )
+          if (params.collaboraters && Array.isArray(params.collaboraters)) {
+            try {
+              await query(`DELETE FROM sponsored_projects_collaborater WHERE sponsored_project_id = ?`, [params.id])
+            } catch (e) {}
+            for (const email of params.collaboraters) {
+              await query(
+                `INSERT INTO sponsored_projects_collaborater(sponsored_project_id, email) VALUES (?, ?)`,
+                [params.id, email]
+              )
+            }
+          }
+          return NextResponse.json(sponsoredResult)
 
-    //     case 'consultancy_projects':
-    //       const consultancyResult = await query(
-    //         `UPDATE consultancy_projects SET 
-    //          project_title = ?,
-    //          role= ?,
-    //          funding_agency = ?,
-    //          financial_outlay = ?,
-    //          start_date = ?,
-    //          period_months = ?,
-    //          investigators = ?,
-    //          status = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.project_title,
-    //           params.role,
-    //           params.funding_agency,
-    //           params.financial_outlay,
-    //           params.start_date,
-    //           params.period_months,
-    //           params.investigators,
-    //           params.status,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //         try { await query(`DELETE FROM consultancy_projects_collaborater WHERE consultancy_projects_id = ?`, [params.id]) } catch (e) {}
-    //         for (const email of params.collaboraters) {
-    //           await query(`INSERT INTO consultancy_projects_collaborater(consultancy_projects_id, email) VALUES (?, ?)`, [params.id, email])
-    //         }
-    //       }
-    //       return NextResponse.json(consultancyResult)
+        case 'consultancy_projects':
+          const consultancyResult = await query(
+            `UPDATE consultancy_projects SET 
+             project_title = ?,
+             role= ?,
+             funding_agency = ?,
+             financial_outlay = ?,
+             start_date = ?,
+             period_months = ?,
+             investigators = ?,
+             status = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.project_title,
+              params.role,
+              params.funding_agency,
+              params.financial_outlay,
+              params.start_date,
+              params.period_months,
+              params.investigators,
+              params.status,
+              params.id,
+              params.email
+            ]
+          )
+          if (params.collaboraters && Array.isArray(params.collaboraters)) {
+            try { await query(`DELETE FROM consultancy_projects_collaborater WHERE consultancy_projects_id = ?`, [params.id]) } catch (e) {}
+            for (const email of params.collaboraters) {
+              await query(`INSERT INTO consultancy_projects_collaborater(consultancy_projects_id, email) VALUES (?, ?)`, [params.id, email])
+            }
+          }
+          return NextResponse.json(consultancyResult)
 
-    //     // IPR and Startups
-    //     case 'ipr':
-    //       const iprResult = await query(
-    //         `UPDATE ipr SET 
-    //          title = ?,
-    //          type = ?,
-    //          registration_date = ?,
-    //          publication_date = ?,
-    //          grant_date = ?,
-    //          grant_no = ?,
-    //          applicant_name = ?,
-    //          inventors = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.title,
-    //           params.iprtype,
-    //           params.registration_date,
-    //           params.publication_date,
-    //           params.grant_date,
-    //           params.grant_no,
-    //           params.applicant_name,
-    //           params.inventors,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //         try { await query(`DELETE FROM ipr_collaborater WHERE ipr_id = ?`, [params.id]) } catch (e) {}
-    //         for (const email of params.collaboraters) {
-    //           await query(`INSERT INTO ipr_collaborater(ipr_id, email) VALUES (?, ?)`, [params.id, email])
-    //         }
-    //       }
-    //       return NextResponse.json(iprResult)
+        // IPR and Startups
+        case 'ipr':
+          const iprResult = await query(
+            `UPDATE ipr SET 
+             title = ?,
+             type = ?,
+             registration_date = ?,
+             publication_date = ?,
+             grant_date = ?,
+             grant_no = ?,
+             applicant_name = ?,
+             inventors = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.title,
+              params.iprtype,
+              params.registration_date,
+              params.publication_date,
+              params.grant_date,
+              params.grant_no,
+              params.applicant_name,
+              params.inventors,
+              params.id,
+              params.email
+            ]
+          )
+          if (params.collaboraters && Array.isArray(params.collaboraters)) {
+            try { await query(`DELETE FROM ipr_collaborater WHERE ipr_id = ?`, [params.id]) } catch (e) {}
+            for (const email of params.collaboraters) {
+              await query(`INSERT INTO ipr_collaborater(ipr_id, email) VALUES (?, ?)`, [params.id, email])
+            }
+          }
+          return NextResponse.json(iprResult)
 
-    //     case 'startups':
-    //       const startupResult = await query(
-    //         `UPDATE startups SET 
-    //          startup_name = ?,
-    //          incubation_place = ?,
-    //          registration_date = ?,
-    //          owners_founders = ?,
-    //          annual_income = ?,
-    //          pan_number = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.startup_name,
-    //           params.incubation_place,
-    //           params.registration_date,
-    //           params.owners_founders,
-    //           params.annual_income,
-    //           params.pan_number,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //         try { await query(`DELETE FROM startups_collaborater WHERE startups_id = ?`, [params.id]) } catch (e) {}
-    //         for (const email of params.collaboraters) {
-    //           await query(`INSERT INTO startups_collaborater(startups_id, email) VALUES (?, ?)`, [params.id, email])
-    //         }
-    //       }
-    //       return NextResponse.json(startupResult)
+        case 'startups':
+          const startupResult = await query(
+            `UPDATE startups SET 
+             startup_name = ?,
+             incubation_place = ?,
+             registration_date = ?,
+             owners_founders = ?,
+             annual_income = ?,
+             pan_number = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.startup_name,
+              params.incubation_place,
+              params.registration_date,
+              params.owners_founders,
+              params.annual_income,
+              params.pan_number,
+              params.id,
+              params.email
+            ]
+          )
+          if (params.collaboraters && Array.isArray(params.collaboraters)) {
+            try { await query(`DELETE FROM startups_collaborater WHERE startups_id = ?`, [params.id]) } catch (e) {}
+            for (const email of params.collaboraters) {
+              await query(`INSERT INTO startups_collaborater(startups_id, email) VALUES (?, ?)`, [params.id, email])
+            }
+          }
+          return NextResponse.json(startupResult)
 
-    //     // Teaching and Activities
-    //     case 'teaching_engagement':
-    //       const teachingResult = await query(
-    //         `UPDATE teaching_engagement SET 
-    //          semester = ?,
-    //          level = ?,
-    //          course_number = ?,
-    //          course_title = ?,
-    //          course_type = ?,
-    //          student_count = ?,
-    //          lectures = ?,
-    //          tutorials = ?,
-    //          practicals = ?,
-    //          total_theory = ?,
-    //          lab_hours = ?,
-    //          years_offered = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.semester,
-    //           params.level,
-    //           params.course_number,
-    //           params.course_title,
-    //           params.course_type,
-    //           params.student_count,
-    //           params.lectures,
-    //           params.tutorials,
-    //           params.practicals,
-    //           params.total_theory,
-    //           params.lab_hours,
-    //           params.years_offered,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       return NextResponse.json(teachingResult)
+        // Teaching and Activities
+        case 'teaching_engagement':
+          const teachingResult = await query(
+            `UPDATE teaching_engagement SET 
+             semester = ?,
+             level = ?,
+             course_number = ?,
+             course_title = ?,
+             course_type = ?,
+             student_count = ?,
+             lectures = ?,
+             tutorials = ?,
+             practicals = ?,
+             total_theory = ?,
+             lab_hours = ?,
+             years_offered = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.semester,
+              params.level,
+              params.course_number,
+              params.course_title,
+              params.course_type,
+              params.student_count,
+              params.lectures,
+              params.tutorials,
+              params.practicals,
+              params.total_theory,
+              params.lab_hours,
+              params.years_offered,
+              params.id,
+              params.email
+            ]
+          )
+          return NextResponse.json(teachingResult)
 
-    //     case 'memberships':
-    //       const membershipUpdateResult = await query(
-    //           `UPDATE memberships 
-    //           SET email = ?, 
-    //               membership_id = ?, 
-    //               membership_society = ?, 
-    //               start = ?, 
-    //               end = ? 
-    //           WHERE id = ?`,
-    //           [
-    //               params.email,
-    //               params.membership_id,
-    //               params.membership_society,
-    //               params.start,
-    //               params.end,
-    //               params.id
-    //           ]
-    //       );
-    //       return NextResponse.json(membershipUpdateResult);
+        case 'memberships':
+          const membershipUpdateResult = await query(
+              `UPDATE memberships 
+              SET email = ?, 
+                  membership_id = ?, 
+                  membership_society = ?, 
+                  start = ?, 
+                  end = ? 
+              WHERE id = ?`,
+              [
+                  params.email,
+                  params.membership_id,
+                  params.membership_society,
+                  params.start,
+                  params.end,
+                  params.id
+              ]
+          );
+          return NextResponse.json(membershipUpdateResult);
 
-    //     case 'project_supervision':
-    //       const supervisionResult = await query(
-    //           `UPDATE project_supervision SET 
-    //               category = ?, 
-    //               project_title = ?, 
-    //               student_details = ?, 
-    //               internal_supervisors = ?, 
-    //               external_supervisors = ?, 
-    //               start_date = ?, 
-    //               end_date = ?
-    //            WHERE id = ? AND email = ?`,
-    //           [
-    //               params.category,
-    //               params.project_title,
-    //               params.student_details,
-    //               params.internal_supervisors,
-    //               params.external_supervisors,
-    //               params.start_date,
-    //               params.end_date, 
-    //               params.id,
-    //               params.email
-    //           ]
-    //       );
-    //       return NextResponse.json(supervisionResult);
+        case 'project_supervision':
+          const supervisionResult = await query(
+              `UPDATE project_supervision SET 
+                  category = ?, 
+                  project_title = ?, 
+                  student_details = ?, 
+                  internal_supervisors = ?, 
+                  external_supervisors = ?, 
+                  start_date = ?, 
+                  end_date = ?
+               WHERE id = ? AND email = ?`,
+              [
+                  params.category,
+                  params.project_title,
+                  params.student_details,
+                  params.internal_supervisors,
+                  params.external_supervisors,
+                  params.start_date,
+                  params.end_date, 
+                  params.id,
+                  params.email
+              ]
+          );
+          return NextResponse.json(supervisionResult);
 
-    //     case 'workshops_conferences':
-    //       const workshopResult = await query(
-    //         `UPDATE workshops_conferences SET 
-    //          event_type = ?,
-    //          role = ?,
-    //          event_name = ?,
-    //          sponsored_by = ?,
-    //          start_date = ?,
-    //          end_date = ?,
-    //          participants_count = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.event_type,
-    //           params.role,
-    //           params.event_name,
-    //           params.sponsored_by,
-    //           params.start_date,
-    //           params.end_date,
-    //           params.participants_count,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       if (params.collaboraters && Array.isArray(params.collaboraters)) {
-    //         try { await query(`DELETE FROM workshops_conferences_collaborater WHERE workshops_conferences_id = ?`, [params.id]) } catch (e) {}
-    //         for (const email of params.collaboraters) {
-    //           await query(`INSERT INTO workshops_conferences_collaborater(workshops_conferences_id, email) VALUES (?, ?)`, [params.id, email])
-    //         }
-    //       }
-    //       return NextResponse.json(workshopResult)
+        case 'workshops_conferences':
+          const workshopResult = await query(
+            `UPDATE workshops_conferences SET 
+             event_type = ?,
+             role = ?,
+             event_name = ?,
+             sponsored_by = ?,
+             start_date = ?,
+             end_date = ?,
+             participants_count = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.event_type,
+              params.role,
+              params.event_name,
+              params.sponsored_by,
+              params.start_date,
+              params.end_date,
+              params.participants_count,
+              params.id,
+              params.email
+            ]
+          )
+          if (params.collaboraters && Array.isArray(params.collaboraters)) {
+            try { await query(`DELETE FROM workshops_conferences_collaborater WHERE workshops_conferences_id = ?`, [params.id]) } catch (e) {}
+            for (const email of params.collaboraters) {
+              await query(`INSERT INTO workshops_conferences_collaborater(workshops_conferences_id, email) VALUES (?, ?)`, [params.id, email])
+            }
+          }
+          return NextResponse.json(workshopResult)
 
-    //     case 'institute_activities':
-    //       const instituteResult = await query(
-    //         `UPDATE institute_activities SET 
-    //          role_position = ?,
-    //          institute_name = ?,
-    //          start_date = ?,
-    //          end_date = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.role_position,
-    //           params.institute_name,
-    //           params.start_date,
-    //           params.end_date,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       return NextResponse.json(instituteResult)
+        case 'institute_activities':
+          const instituteResult = await query(
+            `UPDATE institute_activities SET 
+             role_position = ?,
+             institute_name = ?,
+             start_date = ?,
+             end_date = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.role_position,
+              params.institute_name,
+              params.start_date,
+              params.end_date,
+              params.id,
+              params.email
+            ]
+          )
+          return NextResponse.json(instituteResult)
 
-    //     case 'department_activities':
-    //       const departmentResult = await query(
-    //         `UPDATE department_activities SET 
-    //          activity_description = ?,
-    //          institute_name = ?,
-    //          start_date = ?,
-    //          end_date = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.activity_description,
-    //           params.institute_name,
-    //           params.start_date,
-    //           params.end_date,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       return NextResponse.json(departmentResult)
+        case 'department_activities':
+          const departmentResult = await query(
+            `UPDATE department_activities SET 
+             activity_description = ?,
+             institute_name = ?,
+             start_date = ?,
+             end_date = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.activity_description,
+              params.institute_name,
+              params.start_date,
+              params.end_date,
+              params.id,
+              params.email
+            ]
+          )
+          return NextResponse.json(departmentResult)
 
-    //     case 'internships':
-    //       const internshipResult = await query(
-    //         `UPDATE internships SET 
-    //          student_name = ?,
-    //          qualification = ?,
-    //          affiliation = ?,
-    //          project_title = ?,
-    //          start_date = ?,
-    //          end_date = ?,
-    //          student_type = ?
-    //          WHERE id = ? AND email = ?`,
-    //         [
-    //           params.student_name,
-    //           params.qualification,
-    //           params.affiliation,
-    //           params.project_title,
-    //           params.start_date,
-    //           params.end_date,
-    //           params.student_type,
-    //           params.id,
-    //           params.email
-    //         ]
-    //       )
-    //       return NextResponse.json(internshipResult)
+        case 'internships':
+          const internshipResult = await query(
+            `UPDATE internships SET 
+             student_name = ?,
+             qualification = ?,
+             affiliation = ?,
+             project_title = ?,
+             start_date = ?,
+             end_date = ?,
+             student_type = ?
+             WHERE id = ? AND email = ?`,
+            [
+              params.student_name,
+              params.qualification,
+              params.affiliation,
+              params.project_title,
+              params.start_date,
+              params.end_date,
+              params.student_type,
+              params.id,
+              params.email
+            ]
+          )
+          return NextResponse.json(internshipResult)
 
-    //     case 'education':
-    //       const educationResult = await query(
-    //         `UPDATE education SET 
-    //          certification = ?,
-    //          institution = ?,
-    //          passing_year = ?,
-    //          specialization=?
-    //          WHERE id = ? AND email = ?`,
-    //         [params.certification, params.institution, params.passing_year,params.specialization, params.id, params.email]
-    //       )
-    //       return NextResponse.json(educationResult)
-    //   }
-    // }
-    // uncomment it
-
+        case 'education':
+          const educationResult = await query(
+            `UPDATE education SET 
+             certification = ?,
+             institution = ?,
+             passing_year = ?,
+             specialization=?
+             WHERE id = ? AND email = ?`,
+            [params.certification, params.institution, params.passing_year,params.specialization, params.id, params.email]
+          )
+          return NextResponse.json(educationResult)
+      }
+    }
     return NextResponse.json(
       { message: 'Could not find matching requests' },
       { status: 400 }

--- a/src/app/api/update/route.js
+++ b/src/app/api/update/route.js
@@ -124,7 +124,7 @@ export async function PUT(request) {
             attachments = ?,
             notice_link = ?,
             isVisible = ?,
-            updatedBy = ?
+            updatedBy = ?,
             notice_type = ?,
             notice_sub_type = ?,
             department = ?

--- a/src/app/api/update/route.js
+++ b/src/app/api/update/route.js
@@ -1,119 +1,136 @@
-import { NextResponse } from 'next/server'
-import { query } from '@/lib/db'
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/authOptions'
-
+import { NextResponse } from "next/server";
+import { query } from "@/lib/db";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { notice_sub_types } from '@/lib/const';
 export async function PUT(request) {
   try {
     // Use original authentication for now
-    const session = await getServerSession(authOptions)
-    
+    const session = await getServerSession(authOptions);
+
     if (!session) {
       return NextResponse.json(
-        { message: 'Not authenticated' },
-        { status: 401 }
-      )
+        { message: "Not authenticated" },
+        { status: 401 },
+      );
     }
 
-    const { type, ...params } = await request.json()
-    
+    const { type, ...params } = await request.json();
 
     // Handle profile updates
-    if (type === 'profile') {
+    if (type === "profile") {
       // Check permissions
-      if (session.user.email !== params.email && session.user.role !== 'SUPER_ADMIN') {
+      if (
+        session.user.email !== params.email &&
+        session.user.role !== "SUPER_ADMIN"
+      ) {
         return NextResponse.json(
-          { message: 'Not authorized' },
-          { status: 403 }
-        )
+          { message: "Not authorized" },
+          { status: 403 },
+        );
       }
 
-      let queryParts = []
-      let updateValues = []
+      let queryParts = [];
+      let updateValues = [];
 
       // Handle all possible profile fields
       const fields = [
-          'image',
-          'cv',
-          'name',
-          'designation',
-          'research_interest',
-          'academic_responsibility',
-          'ext_no',
-          'linkedin',
-          'google_scholar',
-          'personal_webpage',
-          'scopus',
-          'vidwan',
-          'orcid'
-      ]
+        "image",
+        "cv",
+        "name",
+        "designation",
+        "research_interest",
+        "academic_responsibility",
+        "ext_no",
+        "linkedin",
+        "google_scholar",
+        "personal_webpage",
+        "scopus",
+        "vidwan",
+        "orcid",
+      ];
 
-      fields.forEach(field => {
-          if (params[field] !== undefined) {
-              queryParts.push(`${field} = ?`)
-              updateValues.push(params[field])
-          }
-      })
+      fields.forEach((field) => {
+        if (params[field] !== undefined) {
+          queryParts.push(`${field} = ?`);
+          updateValues.push(params[field]);
+        }
+      });
 
       // Add email as the last parameter
-      updateValues.push(params.email)
+      updateValues.push(params.email);
 
       const result = await query(
-          `UPDATE user SET ${queryParts.join(', ')} WHERE email = ?`,
-          updateValues
-      )
+        `UPDATE user SET ${queryParts.join(", ")} WHERE email = ?`,
+        updateValues,
+      );
 
-      return NextResponse.json(result)
+      return NextResponse.json(result);
     }
     // Notice updates - Super Admin, Academic Admin, and Department Admin access
-    if (type === 'notice') {
+    if (type === "notice") {
       // First, get the notice details to check authorization
       const notice = await query(
         `SELECT notice_type, department FROM notices WHERE id = ?`,
-        [params.data.id]
+        [params.data.id],
       );
 
       if (!notice || notice.length === 0) {
         return NextResponse.json(
-          { message: 'Notice not found' },
-          { status: 404 }
-        )
+          { message: "Notice not found" },
+          { status: 404 },
+        );
       }
 
       const noticeData = notice[0];
-      
-      console.log('DEBUG: Notice update authorization check')
-      console.log('User role:', session.user.role)
-      console.log('User department:', session.user.department)
-      console.log('Notice department:', noticeData.department)
-      console.log('Notice type:', noticeData.notice_type)
-  
 
-      const canUpdateNotice = 
-        session.user.role === 'SUPER_ADMIN' ||
-        (session.user.role === 'ACADEMIC_ADMIN' && noticeData.notice_type === 'academics') ||
-        (session.user.role === 'DEPT_ADMIN' && 
-         noticeData.notice_type === 'department' && 
-         noticeData.department === session.user.department)
-      
-      console.log('Can update notice:', canUpdateNotice)
-      
+
+
+      const canUpdateNotice =
+        session.user.role === "SUPER_ADMIN" ||
+        (session.user.role === "ACADEMIC_ADMIN" &&
+          noticeData.notice_type === "academics") ||
+        (session.user.role === "DEPT_ADMIN" &&
+          noticeData.notice_type === "department" &&
+          noticeData.department === session.user.department);
+
+
       if (!canUpdateNotice) {
         return NextResponse.json(
-          { message: 'Not authorized to update notices' },
-          { status: 403 }
-        )
+          { message: "Not authorized to update notices" },
+          { status: 403 },
+        );
       }
-
 
       // Log any attachments for debugging
       if (params.data.attachments) {
-        console.log(`Notice update ID ${params.data.id}: Attachments:`, 
-          typeof params.data.attachments === 'string' 
-            ? params.data.attachments 
-            : JSON.stringify(params.data.attachments));
+        console.log(
+          `Notice update ID ${params.data.id}: Attachments:`,
+          typeof params.data.attachments === "string"
+            ? params.data.attachments
+            : JSON.stringify(params.data.attachments),
+        );
       }
-        
+      if (params.data.notice_type) {
+        const noticeTypeKey = params.data.notice_type.toUpperCase();
+        if (notice_sub_types.hasOwnProperty(noticeTypeKey)) {
+          if (
+            !params.data.notice_sub_type ||
+            !notice_sub_types[noticeTypeKey].some(
+            ([_,upKey]) => upKey===params.data.notice_sub_type,
+            )
+          ) {
+            return NextResponse.json(
+              {
+                message:
+                  "Invalid or missing notice_sub_type for notice_type: " +
+                  params.data.notice_type,
+              },
+              { status: 400 },
+            );
+          }
+        }
+      }
       const result = await query(
         `UPDATE notices SET 
             title = ?,
@@ -130,28 +147,30 @@ export async function PUT(request) {
             department = ?
         WHERE id = ?`,
         [
-            params.data.title,
-            new Date().getTime(),
-            params.data.openDate,
-            params.data.closeDate,
-            params.data.important || 0,
-            JSON.stringify(params.data.attachments),
-            params.data.notice_link || null,
-            params.data.isVisible === undefined ? 1 : Number(params.data.isVisible),
-            session.user.email,
-            params.data.notice_type || null,
-            params.data.notice_sub_type || null,
-            params.data.department || null,
-            params.data.id
-        ]
-      )      
-      return NextResponse.json(result)
+          params.data.title,
+          new Date().getTime(),
+          params.data.openDate,
+          params.data.closeDate,
+          params.data.important || 0,
+          JSON.stringify(params.data.attachments),
+          params.data.notice_link || null,
+          params.data.isVisible === undefined
+            ? 1
+            : Number(params.data.isVisible),
+          session?.user?.email,
+          params.data.notice_type || null,
+          params.data.notice_sub_type?.trim()?.toUpperCase() || null,
+          params.data.department || null,
+          params.data.id,
+        ],
+      );
+      return NextResponse.json(result);
     }
 
     // Super Admin only access
-    if (session.user.role === 'SUPER_ADMIN') {
+    if (session.user.role === "SUPER_ADMIN") {
       switch (type) {
-        case 'event':
+        case "event":
           const eventResult = await query(
             `UPDATE events SET 
              title = ?,
@@ -179,28 +198,28 @@ export async function PUT(request) {
               params.data.eventStartDate,
               params.data.eventEndDate,
               params.data.updatedBy || session.user.email,
-              params.data.type || 'general',
-              params.data.id
-            ]
-          )
-          return NextResponse.json(eventResult)
+              params.data.type || "general",
+              params.data.id,
+            ],
+          );
+          return NextResponse.json(eventResult);
 
-        case 'patents':
+        case "patents":
           const patentResult = await query(
-              `UPDATE patents
+            `UPDATE patents
               SET title = ?, description = ?, patent_date = ?, email = ?
               WHERE id = ?`,
-              [
-                  params.title,
-                  params.description,
-                  params.patent_date,
-                  params.email,
-                  params.id 
-              ]
+            [
+              params.title,
+              params.description,
+              params.patent_date,
+              params.email,
+              params.id,
+            ],
           );
           return NextResponse.json(patentResult);
 
-        case 'innovation':
+        case "innovation":
           const innovationResult = await query(
             `UPDATE innovation SET 
              title = ?,
@@ -221,12 +240,12 @@ export async function PUT(request) {
               JSON.stringify(params.data.image),
               params.data.author,
               params.data.email,
-              params.data.id
-            ]
-          )
-          return NextResponse.json(innovationResult)
+              params.data.id,
+            ],
+          );
+          return NextResponse.json(innovationResult);
 
-        case 'news':
+        case "news":
           const newsResult = await query(
             `UPDATE news SET 
              title = ?,
@@ -249,12 +268,12 @@ export async function PUT(request) {
               JSON.stringify(params.data.add_attach),
               params.data.author,
               params.data.email,
-              params.data.id
-            ]
-          )
-          return NextResponse.json(newsResult)
+              params.data.id,
+            ],
+          );
+          return NextResponse.json(newsResult);
 
-        case 'user':
+        case "user":
           if (params.update_social_media_links) {
             const socialResult = await query(
               `UPDATE user SET 
@@ -266,16 +285,16 @@ export async function PUT(request) {
                orcid = ?
                WHERE email = ?`,
               [
-                params.Linkedin || '',
-                params['Google Scholar'] || '',
-                params['Personal Webpage'] || '',
-                params['Scopus'] || '',
-                params['Vidwan'] || '',
-                params['Orcid'] || '',
-                session.user.email
-              ]
-            )
-            return NextResponse.json(socialResult)
+                params.Linkedin || "",
+                params["Google Scholar"] || "",
+                params["Personal Webpage"] || "",
+                params["Scopus"] || "",
+                params["Vidwan"] || "",
+                params["Orcid"] || "",
+                session.user.email,
+              ],
+            );
+            return NextResponse.json(socialResult);
           } else {
             const {
               email,
@@ -287,11 +306,13 @@ export async function PUT(request) {
               research_interest,
               academic_responsibility,
               is_retired,
-              retirement_date
-            } = params
+              retirement_date,
+            } = params;
 
             // Format retirement_date for MySQL or set to NULL
-            const formattedRetirementDate = retirement_date ? new Date(retirement_date).toISOString().slice(0, 10) : null
+            const formattedRetirementDate = retirement_date
+              ? new Date(retirement_date).toISOString().slice(0, 10)
+              : null;
 
             const facultyResult = await query(
               `UPDATE user SET 
@@ -315,10 +336,10 @@ export async function PUT(request) {
                 academic_responsibility || null,
                 is_retired,
                 formattedRetirementDate,
-                email
-              ]
-            )
-            return NextResponse.json(facultyResult)
+                email,
+              ],
+            );
+            return NextResponse.json(facultyResult);
           }
       }
     }
@@ -327,7 +348,7 @@ export async function PUT(request) {
     if (session.user.email === params.email) {
       switch (type) {
         // Academic Records
-        case 'phd_candidates':
+        case "phd_candidates":
           const phdResult = await query(
             `UPDATE phd_candidates SET 
               student_name = ?,
@@ -353,15 +374,15 @@ export async function PUT(request) {
               params.supervisor_type,
               params.registration_date,
               params.id,
-              params.email
-            ]
-          ); 
-          return NextResponse.json(phdResult)
+              params.email,
+            ],
+          );
+          return NextResponse.json(phdResult);
 
-        case 'journal_papers': {
-            try {
-              const journalResult = await query(
-                `UPDATE journal_papers SET 
+        case "journal_papers": {
+          try {
+            const journalResult = await query(
+              `UPDATE journal_papers SET 
                     authors = ?,
                     title = ?,
                     journal_name = ?,
@@ -377,55 +398,59 @@ export async function PUT(request) {
                     foreign_author_details = ?,
                     nationality_type = ?
                 WHERE id = ? AND email = ?`,
-                [
-                  params.authors,
-                  params.title,
-                  params.journal_name,
-                  params.volume,
-                  params.publication_year,
-                  params.pages,
-                  params.journal_quartile,
-                  params.publication_date,
-                  params.student_involved,
-                  params.student_details,
-                  params.doi_url,
-                  params.indexing,
-                  params.foreign_author_details,
-                  params.nationality_type,
-                  params.id,
-                  params.email
-                ]
+              [
+                params.authors,
+                params.title,
+                params.journal_name,
+                params.volume,
+                params.publication_year,
+                params.pages,
+                params.journal_quartile,
+                params.publication_date,
+                params.student_involved,
+                params.student_details,
+                params.doi_url,
+                params.indexing,
+                params.foreign_author_details,
+                params.nationality_type,
+                params.id,
+                params.email,
+              ],
+            );
+
+            if (params.collaboraters && Array.isArray(params.collaboraters)) {
+              const existingRows = await query(
+                `SELECT email FROM journal_paper_collaborater WHERE journal_paper_id = ?`,
+                [params.id],
+              );
+              const existingEmails = existingRows.map((row) => row.email);
+
+              const newEmails = params.collaboraters.filter(
+                (e) => !existingEmails.includes(e),
+              );
+              const removedEmails = existingEmails.filter(
+                (e) => !params.collaboraters.includes(e),
               );
 
-              if (params.collaboraters && Array.isArray(params.collaboraters)) {
-                const existingRows = await query(
-                  `SELECT email FROM journal_paper_collaborater WHERE journal_paper_id = ?`,
-                  [params.id]
-                );
-                const existingEmails = existingRows.map(row => row.email);
-
-                const newEmails = params.collaboraters.filter(e => !existingEmails.includes(e));
-                const removedEmails = existingEmails.filter(e => !params.collaboraters.includes(e));
-
-                for (const email of newEmails) {
-                  await query(
-                    `INSERT INTO journal_paper_collaborater (journal_paper_id, email)
+              for (const email of newEmails) {
+                await query(
+                  `INSERT INTO journal_paper_collaborater (journal_paper_id, email)
                     VALUES (?, ?)`,
-                    [params.id, email]
-                  );
-                }
-
-                for (const email of removedEmails) {
-                  await query(
-                    `DELETE FROM journal_paper_collaborater 
-                    WHERE journal_paper_id = ? AND email = ?`,
-                    [params.id, email]
-                  );
-                }
+                  [params.id, email],
+                );
               }
 
-              const papersWithCollaborators = await query(
-                `SELECT jp.*, 
+              for (const email of removedEmails) {
+                await query(
+                  `DELETE FROM journal_paper_collaborater 
+                    WHERE journal_paper_id = ? AND email = ?`,
+                  [params.id, email],
+                );
+              }
+            }
+
+            const papersWithCollaborators = await query(
+              `SELECT jp.*, 
                         GROUP_CONCAT(jpc.email) AS collaboraters
                 FROM journal_papers jp
                 LEFT JOIN journal_paper_collaborater jpc
@@ -433,25 +458,24 @@ export async function PUT(request) {
                 WHERE jp.id = ?
                 GROUP BY jp.id
                 ORDER BY jp.publication_year DESC`,
-                [params.id]
-              );
+              [params.id],
+            );
 
-              return NextResponse.json({
-                success: true,
-                message: 'Journal paper and collaborators updated successfully',
-                data: papersWithCollaborators[0] || {}
-              });
-
-            } catch (error) {
-              console.error('[Journal Paper Update Error]:', error);
-              return NextResponse.json(
-                { success: false, error: error.message },
-                { status: 500 }
-              );
-            }
+            return NextResponse.json({
+              success: true,
+              message: "Journal paper and collaborators updated successfully",
+              data: papersWithCollaborators[0] || {},
+            });
+          } catch (error) {
+            console.error("[Journal Paper Update Error]:", error);
+            return NextResponse.json(
+              { success: false, error: error.message },
+              { status: 500 },
+            );
           }
+        }
 
-        case 'conference_papers':
+        case "conference_papers":
           const conferenceResult = await query(
             `UPDATE conference_papers SET 
               authors = ?,
@@ -489,20 +513,23 @@ export async function PUT(request) {
               params.student_name ? "yes" : "no",
               params.doi,
               params.id,
-              params.email
-            ]
-          )
+              params.email,
+            ],
+          );
 
           if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { 
-              await query(`DELETE FROM conference_papers_collaborater WHERE conference_papers_id = ?`, [params.id]) 
+            try {
+              await query(
+                `DELETE FROM conference_papers_collaborater WHERE conference_papers_id = ?`,
+                [params.id],
+              );
             } catch (e) {}
-            
+
             for (const email of params.collaboraters) {
               await query(
                 `INSERT INTO conference_papers_collaborater(conference_papers_id, email) VALUES (?, ?)`,
-                [params.id, email]
-              )
+                [params.id, email],
+              );
             }
           }
 
@@ -513,14 +540,15 @@ export async function PUT(request) {
                ON cp.id = cpc.conference_papers_id
              WHERE cp.id = ?
              GROUP BY cp.id`,
-            [params.id]
-          )
+            [params.id],
+          );
 
-          return NextResponse.json({ conference: conferencesWithCollaborators[0] || null })
-
+          return NextResponse.json({
+            conference: conferencesWithCollaborators[0] || null,
+          });
 
         // Books
-        case 'textbooks':
+        case "textbooks":
           const textbookResult = await query(
             `UPDATE textbooks SET 
              title = ?,
@@ -540,18 +568,26 @@ export async function PUT(request) {
               params.scopus,
               params.doi,
               params.id,
-              params.email
-            ]
-          )
+              params.email,
+            ],
+          );
           if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM textbooks_collaborater WHERE textbooks_id = ?`, [params.id]) } catch (e) {}
+            try {
+              await query(
+                `DELETE FROM textbooks_collaborater WHERE textbooks_id = ?`,
+                [params.id],
+              );
+            } catch (e) {}
             for (const email of params.collaboraters) {
-              await query(`INSERT INTO textbooks_collaborater(textbooks_id, email) VALUES (?, ?)`, [params.id, email])
+              await query(
+                `INSERT INTO textbooks_collaborater(textbooks_id, email) VALUES (?, ?)`,
+                [params.id, email],
+              );
             }
           }
-          return NextResponse.json(textbookResult)
+          return NextResponse.json(textbookResult);
 
-        case 'edited_books':
+        case "edited_books":
           const editedBookResult = await query(
             `UPDATE edited_books SET 
              title = ?,
@@ -571,13 +607,21 @@ export async function PUT(request) {
               params.scopus,
               params.doi,
               params.id,
-              params.email
-            ]
-          )
+              params.email,
+            ],
+          );
           if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM edited_books_collaborater WHERE edited_books_id = ?`, [params.id]) } catch (e) {}
+            try {
+              await query(
+                `DELETE FROM edited_books_collaborater WHERE edited_books_id = ?`,
+                [params.id],
+              );
+            } catch (e) {}
             for (const email of params.collaboraters) {
-              await query(`INSERT INTO edited_books_collaborater(edited_books_id, email) VALUES (?, ?)`, [params.id, email])
+              await query(
+                `INSERT INTO edited_books_collaborater(edited_books_id, email) VALUES (?, ?)`,
+                [params.id, email],
+              );
             }
           }
           const updatedEditedBooks = await query(
@@ -587,12 +631,14 @@ export async function PUT(request) {
                ON eb.id = ebc.edited_books_id
              WHERE eb.id = ?
              GROUP BY eb.id`,
-            [params.id]
-          )
+            [params.id],
+          );
 
-          return NextResponse.json({ editedBook: updatedEditedBooks[0] || null })
+          return NextResponse.json({
+            editedBook: updatedEditedBooks[0] || null,
+          });
 
-        case 'book_chapters':
+        case "book_chapters":
           const chapterResult = await query(
             `UPDATE book_chapters SET 
              authors = ?,
@@ -616,19 +662,27 @@ export async function PUT(request) {
               params.scopus,
               params.doi,
               params.id,
-              params.email
-            ]
-          )
+              params.email,
+            ],
+          );
           if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM book_chapters_collaborater WHERE book_chapters_id = ?`, [params.id]) } catch (e) {}
+            try {
+              await query(
+                `DELETE FROM book_chapters_collaborater WHERE book_chapters_id = ?`,
+                [params.id],
+              );
+            } catch (e) {}
             for (const email of params.collaboraters) {
-              await query(`INSERT INTO book_chapters_collaborater(book_chapters_id, email) VALUES (?, ?)`, [params.id, email])
+              await query(
+                `INSERT INTO book_chapters_collaborater(book_chapters_id, email) VALUES (?, ?)`,
+                [params.id, email],
+              );
             }
           }
-          return NextResponse.json(chapterResult)
+          return NextResponse.json(chapterResult);
 
         // Projects
-        case 'sponsored_projects':
+        case "sponsored_projects":
           const sponsoredResult = await query(
             `UPDATE sponsored_projects SET 
              project_title = ?,
@@ -654,23 +708,26 @@ export async function PUT(request) {
               params.status,
               params.funds_received,
               params.id,
-              params.email
-            ]
-          )
+              params.email,
+            ],
+          );
           if (params.collaboraters && Array.isArray(params.collaboraters)) {
             try {
-              await query(`DELETE FROM sponsored_projects_collaborater WHERE sponsored_project_id = ?`, [params.id])
+              await query(
+                `DELETE FROM sponsored_projects_collaborater WHERE sponsored_project_id = ?`,
+                [params.id],
+              );
             } catch (e) {}
             for (const email of params.collaboraters) {
               await query(
                 `INSERT INTO sponsored_projects_collaborater(sponsored_project_id, email) VALUES (?, ?)`,
-                [params.id, email]
-              )
+                [params.id, email],
+              );
             }
           }
-          return NextResponse.json(sponsoredResult)
+          return NextResponse.json(sponsoredResult);
 
-        case 'consultancy_projects':
+        case "consultancy_projects":
           const consultancyResult = await query(
             `UPDATE consultancy_projects SET 
              project_title = ?,
@@ -692,19 +749,27 @@ export async function PUT(request) {
               params.investigators,
               params.status,
               params.id,
-              params.email
-            ]
-          )
+              params.email,
+            ],
+          );
           if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM consultancy_projects_collaborater WHERE consultancy_projects_id = ?`, [params.id]) } catch (e) {}
+            try {
+              await query(
+                `DELETE FROM consultancy_projects_collaborater WHERE consultancy_projects_id = ?`,
+                [params.id],
+              );
+            } catch (e) {}
             for (const email of params.collaboraters) {
-              await query(`INSERT INTO consultancy_projects_collaborater(consultancy_projects_id, email) VALUES (?, ?)`, [params.id, email])
+              await query(
+                `INSERT INTO consultancy_projects_collaborater(consultancy_projects_id, email) VALUES (?, ?)`,
+                [params.id, email],
+              );
             }
           }
-          return NextResponse.json(consultancyResult)
+          return NextResponse.json(consultancyResult);
 
         // IPR and Startups
-        case 'ipr':
+        case "ipr":
           const iprResult = await query(
             `UPDATE ipr SET 
              title = ?,
@@ -726,18 +791,25 @@ export async function PUT(request) {
               params.applicant_name,
               params.inventors,
               params.id,
-              params.email
-            ]
-          )
+              params.email,
+            ],
+          );
           if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM ipr_collaborater WHERE ipr_id = ?`, [params.id]) } catch (e) {}
+            try {
+              await query(`DELETE FROM ipr_collaborater WHERE ipr_id = ?`, [
+                params.id,
+              ]);
+            } catch (e) {}
             for (const email of params.collaboraters) {
-              await query(`INSERT INTO ipr_collaborater(ipr_id, email) VALUES (?, ?)`, [params.id, email])
+              await query(
+                `INSERT INTO ipr_collaborater(ipr_id, email) VALUES (?, ?)`,
+                [params.id, email],
+              );
             }
           }
-          return NextResponse.json(iprResult)
+          return NextResponse.json(iprResult);
 
-        case 'startups':
+        case "startups":
           const startupResult = await query(
             `UPDATE startups SET 
              startup_name = ?,
@@ -755,19 +827,27 @@ export async function PUT(request) {
               params.annual_income,
               params.pan_number,
               params.id,
-              params.email
-            ]
-          )
+              params.email,
+            ],
+          );
           if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM startups_collaborater WHERE startups_id = ?`, [params.id]) } catch (e) {}
+            try {
+              await query(
+                `DELETE FROM startups_collaborater WHERE startups_id = ?`,
+                [params.id],
+              );
+            } catch (e) {}
             for (const email of params.collaboraters) {
-              await query(`INSERT INTO startups_collaborater(startups_id, email) VALUES (?, ?)`, [params.id, email])
+              await query(
+                `INSERT INTO startups_collaborater(startups_id, email) VALUES (?, ?)`,
+                [params.id, email],
+              );
             }
           }
-          return NextResponse.json(startupResult)
+          return NextResponse.json(startupResult);
 
         // Teaching and Activities
-        case 'teaching_engagement':
+        case "teaching_engagement":
           const teachingResult = await query(
             `UPDATE teaching_engagement SET 
              semester = ?,
@@ -797,34 +877,34 @@ export async function PUT(request) {
               params.lab_hours,
               params.years_offered,
               params.id,
-              params.email
-            ]
-          )
-          return NextResponse.json(teachingResult)
+              params.email,
+            ],
+          );
+          return NextResponse.json(teachingResult);
 
-        case 'memberships':
+        case "memberships":
           const membershipUpdateResult = await query(
-              `UPDATE memberships 
+            `UPDATE memberships 
               SET email = ?, 
                   membership_id = ?, 
                   membership_society = ?, 
                   start = ?, 
                   end = ? 
               WHERE id = ?`,
-              [
-                  params.email,
-                  params.membership_id,
-                  params.membership_society,
-                  params.start,
-                  params.end,
-                  params.id
-              ]
+            [
+              params.email,
+              params.membership_id,
+              params.membership_society,
+              params.start,
+              params.end,
+              params.id,
+            ],
           );
           return NextResponse.json(membershipUpdateResult);
 
-        case 'project_supervision':
+        case "project_supervision":
           const supervisionResult = await query(
-              `UPDATE project_supervision SET 
+            `UPDATE project_supervision SET 
                   category = ?, 
                   project_title = ?, 
                   student_details = ?, 
@@ -833,21 +913,21 @@ export async function PUT(request) {
                   start_date = ?, 
                   end_date = ?
                WHERE id = ? AND email = ?`,
-              [
-                  params.category,
-                  params.project_title,
-                  params.student_details,
-                  params.internal_supervisors,
-                  params.external_supervisors,
-                  params.start_date,
-                  params.end_date, 
-                  params.id,
-                  params.email
-              ]
+            [
+              params.category,
+              params.project_title,
+              params.student_details,
+              params.internal_supervisors,
+              params.external_supervisors,
+              params.start_date,
+              params.end_date,
+              params.id,
+              params.email,
+            ],
           );
           return NextResponse.json(supervisionResult);
 
-        case 'workshops_conferences':
+        case "workshops_conferences":
           const workshopResult = await query(
             `UPDATE workshops_conferences SET 
              event_type = ?,
@@ -867,18 +947,26 @@ export async function PUT(request) {
               params.end_date,
               params.participants_count,
               params.id,
-              params.email
-            ]
-          )
+              params.email,
+            ],
+          );
           if (params.collaboraters && Array.isArray(params.collaboraters)) {
-            try { await query(`DELETE FROM workshops_conferences_collaborater WHERE workshops_conferences_id = ?`, [params.id]) } catch (e) {}
+            try {
+              await query(
+                `DELETE FROM workshops_conferences_collaborater WHERE workshops_conferences_id = ?`,
+                [params.id],
+              );
+            } catch (e) {}
             for (const email of params.collaboraters) {
-              await query(`INSERT INTO workshops_conferences_collaborater(workshops_conferences_id, email) VALUES (?, ?)`, [params.id, email])
+              await query(
+                `INSERT INTO workshops_conferences_collaborater(workshops_conferences_id, email) VALUES (?, ?)`,
+                [params.id, email],
+              );
             }
           }
-          return NextResponse.json(workshopResult)
+          return NextResponse.json(workshopResult);
 
-        case 'institute_activities':
+        case "institute_activities":
           const instituteResult = await query(
             `UPDATE institute_activities SET 
              role_position = ?,
@@ -892,12 +980,12 @@ export async function PUT(request) {
               params.start_date,
               params.end_date,
               params.id,
-              params.email
-            ]
-          )
-          return NextResponse.json(instituteResult)
+              params.email,
+            ],
+          );
+          return NextResponse.json(instituteResult);
 
-        case 'department_activities':
+        case "department_activities":
           const departmentResult = await query(
             `UPDATE department_activities SET 
              activity_description = ?,
@@ -911,12 +999,12 @@ export async function PUT(request) {
               params.start_date,
               params.end_date,
               params.id,
-              params.email
-            ]
-          )
-          return NextResponse.json(departmentResult)
+              params.email,
+            ],
+          );
+          return NextResponse.json(departmentResult);
 
-        case 'internships':
+        case "internships":
           const internshipResult = await query(
             `UPDATE internships SET 
              student_name = ?,
@@ -936,12 +1024,12 @@ export async function PUT(request) {
               params.end_date,
               params.student_type,
               params.id,
-              params.email
-            ]
-          )
-          return NextResponse.json(internshipResult)
+              params.email,
+            ],
+          );
+          return NextResponse.json(internshipResult);
 
-        case 'education':
+        case "education":
           const educationResult = await query(
             `UPDATE education SET 
              certification = ?,
@@ -949,21 +1037,24 @@ export async function PUT(request) {
              passing_year = ?,
              specialization=?
              WHERE id = ? AND email = ?`,
-            [params.certification, params.institution, params.passing_year,params.specialization, params.id, params.email]
-          )
-          return NextResponse.json(educationResult)
+            [
+              params.certification,
+              params.institution,
+              params.passing_year,
+              params.specialization,
+              params.id,
+              params.email,
+            ],
+          );
+          return NextResponse.json(educationResult);
       }
     }
     return NextResponse.json(
-      { message: 'Could not find matching requests' },
-      { status: 400 }
-    )
-
+      { message: "Could not find matching requests" },
+      { status: 400 },
+    );
   } catch (error) {
-    console.error('API Error:', error)
-    return NextResponse.json(
-      { message: error.message },
-      { status: 500 }
-    )
+    console.error("API Error:", error);
+    return NextResponse.json({ message: error.message }, { status: 500 });
   }
 }

--- a/src/lib/const.js
+++ b/src/lib/const.js
@@ -3,13 +3,22 @@ export const administrationList = new Map([
   ['academicintranet', 'Intranet - Academic and Exam Notice'],
   ['genralintranet', 'Intranet - General Notice'],
   ['tender', 'Tender'],
-  ['jrfsrf', 'JRF SRF'],
-  ['facultystaffjob', 'Faculty Staff Job Recruitment'],
+  ['job', 'JOB'],
   ['bogminutes', 'BOG/FC/BWC Minutes'],
   ['senateminutes', 'Senate Minutes'],
   ['annualreport', 'Annual Reports'],
   ['newcampus', 'New Campus']
 ])
+
+export const notice_sub_types = {
+  "JOB": [
+    ["regularteaching", "Regular Teaching"],
+    ["nonregularteaching", "Non-Regular Teaching"],
+    ["regularnonteaching", "Regular Non-Teaching"],
+    ["nonregularnonteaching", "Non-Regular Non-Teaching"],
+    ["jdrfsrf", "JDRF/SRF"]
+  ]
+}
 
 export const depList = new Map([
   ['arch', 'Architecture'],


### PR DESCRIPTION
- Added a nullable `notice_sub_type` column to `notices` table:
  ```sql
  ALTER TABLE notices ADD COLUMN notice_sub_type VARCHAR(255) NULL;
  ```

## `/api/notice` GET:  
  Can now filter by both `type` and `notice_sub_type` (case-insensitive).
#### Example: Valid Request

```
GET http://localhost:3000/api/notice?type=JOb&notice_sub_type=rEGULARTEACHING
```

#### Example: Successful Response (`200 OK`)

```json
[
  {
    "id": "12345",
    "title": "Holiday Announcement",
    "timestamp": "1775655248700",
    "openDate": "1717200000000",
    "closeDate": "1717545600000",
    "important": 1,
    "isVisible": 1,
    "attachments": [
      {
        "name": "HolidayList.pdf",
        "url": "https://example.com/HolidayList.pdf"
      }
    ],
    "email": "admin@nitp.ac.in",
    "isDept": 0,
    "notice_link": "https://example.com/notices/holiday",
    "notice_type": "JOB",
    "updatedBy": "shivamg.ug24.cs@nitp.ac.in",
    "updatedAt": "1775655248700",
    "department": "CSE",
    "notice_sub_type": "REGULARTEACHING"
  }
]
```

- If results are found, an array of notices is returned (`200 OK`) as above.
- Notice that both `type` and `notice_sub_type` accept any casing but are normalized to UPPERCASE in responses.
- If the `type` is invalid, you get:

```json
{
  "message": "Invalid type parameter"
}
```
---
## `/api/create` POST and `/api/update` PUT:  
  If a notice's `notice_type` requires sub-type, a valid `notice_sub_type` **must** be provided. Payloads missing required sub-type get an error:
  ```json
  { "message": "Invalid or missing notice_sub_type for notice_type: job" }
  ```

- All API responses use UPPERCASE for `notice_type` & `notice_sub_type`.
- Authorization unchanged.
- See code/docs for schema and payload examples.
