### PR TITLE
Sairaj 002 redis cache publications

### DIFF
--- a/src/app/api/create/route.js
+++ b/src/app/api/create/route.js
@@ -6,6 +6,7 @@ import { ROLES, hasAccess } from '@/lib/roles'
 import { authOptions } from '@/lib/authOptions'
 import { invalidateProfileIfNeeded } from '@/lib/profileCache'
 import { notice_sub_types } from '@/lib/const';
+import { invalidatePublicationsCache } from '@/lib/publicationsCache'
 
 export async function POST(request) {
   const session = await getServerSession(authOptions)
@@ -16,7 +17,7 @@ export async function POST(request) {
       { status: 403 }
     )
   }
-
+  
   try {
     const { type, ...params } = await request.json()
     
@@ -109,6 +110,7 @@ export async function POST(request) {
             ]
           )
           await invalidateProfileIfNeeded(type, params);
+          await invalidatePublicationsCache(null);
           return NextResponse.json(userResult)
 
         case 'webteam':
@@ -272,6 +274,7 @@ export async function POST(request) {
                  ORDER BY jp.publication_year DESC`
             );
             await invalidateProfileIfNeeded(type, params);
+            await invalidatePublicationsCache(params.email);
             return NextResponse.json({ journalResult, papersWithCollaborators });
 
           case 'conference_papers':
@@ -335,6 +338,7 @@ export async function POST(request) {
               [params.id]
             )
             await invalidateProfileIfNeeded(type, params);
+            await invalidatePublicationsCache(params.email);
 
             return NextResponse.json({ conference: conferencesWithCollaborators[0] || null })
 
@@ -363,6 +367,7 @@ export async function POST(request) {
               }
             }
             await invalidateProfileIfNeeded(type, params);
+            await invalidatePublicationsCache(params.email);
             return NextResponse.json(textbookResult)
 
           case 'edited_books':
@@ -426,6 +431,8 @@ export async function POST(request) {
               }
             }
             await invalidateProfileIfNeeded(type, params);
+            await invalidatePublicationsCache(params.email);
+            
             return NextResponse.json(chapterResult)
 
           case 'sponsored_projects':

--- a/src/app/api/delete/route.js
+++ b/src/app/api/delete/route.js
@@ -5,6 +5,8 @@ import { ROLES } from '@/lib/roles'
 import { authOptions } from '@/lib/authOptions'
 import { deleteS3File, extractS3KeyFromUrl } from '@/lib/utils' 
 import { invalidateProfileIfNeeded } from '@/lib/profileCache'
+import { invalidatePublicationsCache } from '@/lib/publicationsCache';
+import { PUBLICATION_TYPES } from '../../../lib/const'
 
 export async function POST(request) {
   const session = await getServerSession(authOptions)
@@ -150,6 +152,7 @@ export async function POST(request) {
             ).catch(e => console.error(`Error deleting from ${table}:`, e))
           }
           await invalidateProfileIfNeeded(type, params);
+          await invalidatePublicationsCache(null);
           return NextResponse.json({ message: 'User and related data deleted successfully' })
 
         case 'webteam':
@@ -216,6 +219,9 @@ export async function POST(request) {
             [params.id, params.email]
           )
           await invalidateProfileIfNeeded(type, params);
+          if (PUBLICATION_TYPES.includes(type)) {
+            await invalidatePublicationsCache(params.email);
+          }
           return NextResponse.json(journalResult)
 
         case 'conference_papers':
@@ -224,6 +230,9 @@ export async function POST(request) {
             [params.id, params.email]
           )
           await invalidateProfileIfNeeded(type, params);
+          if (PUBLICATION_TYPES.includes(type)) {
+            await invalidatePublicationsCache(params.email);
+          }
           return NextResponse.json(conferenceResult)
 
         case 'textbooks':
@@ -232,6 +241,9 @@ export async function POST(request) {
             [params.id, params.email]
           )
           await invalidateProfileIfNeeded(type, params);
+          if (PUBLICATION_TYPES.includes(type)) {
+            await invalidatePublicationsCache(params.email);
+          }
           return NextResponse.json(textbookResult)
 
         case 'edited_books':
@@ -248,6 +260,9 @@ export async function POST(request) {
             [params.id, params.email]
           )
           await invalidateProfileIfNeeded(type, params);
+          if (PUBLICATION_TYPES.includes(type)) {
+            await invalidatePublicationsCache(params.email);
+          }
           return NextResponse.json(chapterResult)
 
         case 'sponsored_projects':

--- a/src/app/api/publications/route.js
+++ b/src/app/api/publications/route.js
@@ -1,10 +1,20 @@
 import { NextResponse } from 'next/server'
 import { query } from '@/lib/db'
 import { depList } from '@/lib/const'
+import { getPublicationsKey,getPublicationsCache,setPublicationsCache } from '@/lib/publicationsCache'
+
 export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url)
-    const type = searchParams.get('type')
+    const type = (searchParams.get('type') || 'all').toLowerCase();
+
+    // GET CACHE
+    const cacheKey = getPublicationsKey(type);
+    const cached = await getPublicationsCache(cacheKey);
+    if (cached) {
+      console.log("CACHE HIT");
+      return NextResponse.json(cached);
+    }
 
     let results
     switch (type) {
@@ -22,6 +32,10 @@ export async function GET(request) {
           `SELECT * FROM book_chapters`
         );
         const data = [...conference_papers,...textbooks_data,...journal_papers,...book_chapters];
+
+        // SET CACHE
+        await setPublicationsCache(cacheKey, data);
+
         return NextResponse.json(data);
 
       default:
@@ -48,6 +62,7 @@ export async function GET(request) {
             [depList.get(type)]
           );
           const data = [...textbooks_data, ...journal_papers, ...book_chapters];
+          await setPublicationsCache(cacheKey, data);
           return NextResponse.json(data);
         } else {
           return NextResponse.json(

--- a/src/app/api/update/route.js
+++ b/src/app/api/update/route.js
@@ -301,7 +301,7 @@ export async function PUT(request) {
               ]
             )
             await invalidateProfileIfNeeded(type, params);
-            await invalidatePublicationsCache(null);
+            
             return NextResponse.json(socialResult)
           } else {
             const {

--- a/src/app/api/update/route.js
+++ b/src/app/api/update/route.js
@@ -3,6 +3,9 @@ import { query } from '@/lib/db'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/authOptions'
 import { invalidateProfileIfNeeded } from '@/lib/profileCache'
+import { invalidatePublicationsCache } from '@/lib/publicationsCache';
+import { PUBLICATION_TYPES } from '../../../lib/const'
+
 import { notice_sub_types } from '@/lib/const';
 export async function PUT(request) {
   try {
@@ -298,6 +301,7 @@ export async function PUT(request) {
               ]
             )
             await invalidateProfileIfNeeded(type, params);
+            await invalidatePublicationsCache(null);
             return NextResponse.json(socialResult)
           } else {
             const {
@@ -344,6 +348,7 @@ export async function PUT(request) {
               ]
             )
             await invalidateProfileIfNeeded(type, params);
+            await invalidatePublicationsCache(null);
             return NextResponse.json(facultyResult)
           }
       }
@@ -467,6 +472,9 @@ export async function PUT(request) {
                 [params.id]
               );
               await invalidateProfileIfNeeded(type, params);
+              if (PUBLICATION_TYPES.includes(type)) {
+                await invalidatePublicationsCache(params.email);
+              }
               return NextResponse.json({
                 success: true,
                 message: 'Journal paper and collaborators updated successfully',
@@ -481,7 +489,7 @@ export async function PUT(request) {
               );
             }
           }
-        }
+        
 
         case "conference_papers":
           const conferenceResult = await query(
@@ -551,6 +559,9 @@ export async function PUT(request) {
             [params.id]
           )
           await invalidateProfileIfNeeded(type, params);
+          if (PUBLICATION_TYPES.includes(type)) {
+            await invalidatePublicationsCache(params.email);
+          }
           return NextResponse.json({ conference: conferencesWithCollaborators[0] || null })
 
           return NextResponse.json({
@@ -596,6 +607,9 @@ export async function PUT(request) {
             }
           }
           await invalidateProfileIfNeeded(type, params);
+          if (PUBLICATION_TYPES.includes(type)) {
+            await invalidatePublicationsCache(params.email);
+          }
           return NextResponse.json(textbookResult)
 
         case "edited_books":
@@ -689,6 +703,9 @@ export async function PUT(request) {
             }
           }
           await invalidateProfileIfNeeded(type, params);
+          if (PUBLICATION_TYPES.includes(type)) {
+            await invalidatePublicationsCache(params.email);
+          }
           return NextResponse.json(chapterResult)
 
         // Projects

--- a/src/lib/const.js
+++ b/src/lib/const.js
@@ -103,3 +103,10 @@ export const facultyTables = [
   
 ]
 
+// For invalidating redis cache of publications
+export const PUBLICATION_TYPES = [
+  'journal_papers',
+  'conference_papers',
+  'textbooks',
+  'book_chapters'
+];

--- a/src/lib/profileCache.js
+++ b/src/lib/profileCache.js
@@ -65,6 +65,22 @@ export async function getCachedUserProfile(email) {
 /**
  * Invalidate profile cache (when profile is updated)
  */
+/**
+ * Invalidate profile cache (when profile is updated)
+ */
+export async function invalidateUserProfile(email) {
+  try {
+    const redis = getRedisClient();
+    const key = getCacheKey(email);
+    
+    await redis.del(key);
+    console.log(`✓ Profile cache invalidated for ${email}`);
+    return true;
+  } catch (error) {
+    console.error('Error invalidating profile:', error);
+    return false;
+  }
+}
 
 export async function invalidateProfileIfNeeded(type, params) {
   // Tables that are part of the profile data

--- a/src/lib/publicationsCache.js
+++ b/src/lib/publicationsCache.js
@@ -1,0 +1,111 @@
+import { connectRedis } from '@/lib/redis';
+import { depList } from '@/lib/const';
+import { query } from '@/lib/db';
+
+const PREFIX = 'publications';
+
+// generate key
+export const getPublicationsKey = (type) => {
+  return `${PREFIX}:${(type || 'all').toLowerCase()}`;
+};
+
+// helper function
+export const getDepartmentFromEmail = async (email) => {
+  try {
+    const result = await query(
+      `SELECT department FROM user WHERE email = ?`,
+      [email]
+    );
+
+    return result?.[0]?.department || null;
+  } catch (err) {
+    console.error('[Dept Fetch Error]', err.message);
+    return null;
+  }
+};
+
+// GET cache (SAFE)
+export const getPublicationsCache = async (key) => {
+  try {
+    const redis = await connectRedis();
+
+    const data = await redis.get(key);
+    // return data ? JSON.parse(data) : null;
+    if (!data){
+      console.log(`Cache MISS → ${key}`);
+      return null;
+    }
+    console.log(`Cache HIT → ${key}`);
+    try {
+      return JSON.parse(data);
+    } catch (parseErr) {
+      console.error('[Redis PARSE Error]', parseErr.message);
+      return null; // fallback to DB
+    }
+
+  } catch (err) {
+    console.error('[Redis GET Error]', err.message);
+    return null;
+  }
+};
+
+// SET cache
+export const setPublicationsCache = async (key, data) => {
+  try {
+    const redis = await connectRedis();
+
+    await redis.set(key, JSON.stringify(data), 'EX', 21600);
+    // await redis.sadd(`${PREFIX}:keys`, key);
+    console.log(`Cache SET → ${key}`);
+  } catch (err) {
+    console.error('[Redis SET Error]', err.message);
+  }
+};
+
+// invalidate cache
+export const invalidatePublicationsCache = async (email=null) => {
+  try {
+    const redis = await connectRedis();
+
+    const keys = [];
+
+    if (!email) {
+      // PUBLICATIONS CACHE CLEAR
+      const allKeys = await redis.keys(`${PREFIX}:*`);
+      if (allKeys.length) await redis.del(...allKeys);
+      return;
+    }
+    //KEYS TO INVALIDATE
+    keys.push(getPublicationsKey('all'));
+    if(email){
+      const department = await getDepartmentFromEmail(email);
+    
+      if(department){
+        // Find matching type key from depList
+        const normalizedDept = department.trim().toLowerCase();
+        const typeKey = [...depList.entries()]
+          .find(([key, value]) => value.trim().toLowerCase() === normalizedDept)?.[0];
+          
+        if (typeKey) {
+          keys.push(getPublicationsKey(typeKey));
+        }
+      }
+      if (!department) {
+        console.warn('Department not found, clearing all publications cache');
+        
+        const allKeys = await redis.keys(`${PREFIX}:*`);
+        if (allKeys.length) await redis.del(...allKeys);
+        return;
+      }
+    }
+    if (keys.length > 0) {
+      await redis.del(...keys);
+      console.log(`Cleared publications cache (${keys.length} keys)`);
+    }
+    // await redis.del(`${PREFIX}:keys`);
+  } catch (err) {
+    console.error('[Redis INVALIDATE Error]', err.message);
+  }
+};
+
+// note: invalidatePublicationsCache -> here, if invalidate failed due to redis error, then say redis live again then we might get stale data, so we need to set TTL accordingly or implement some other strategy


### PR DESCRIPTION
# Add Redis-based caching for Publications API

---

# Branch  
Sairaj-002-Redis-Cache-Publications

---

# Description  

- Added Redis caching for publications  
- Reduced API response time significantly  
- Centralized cache handling  
- Ensured data consistency via invalidation  

---
# Why This Change Was Required  

The publications data on the NIT Patna main website was being fetched with an average response time of **4–5 seconds**, primarily due to:

- Multiple database joins
- Large volume of publications data
- Repeated fetching of same data across requests

This led to:
- Slow page load times 
- Poor user experience 
- Unnecessary database load 

To address this, **Redis caching** was introduced to store frequently accessed publications data and serve it instantly.

<img width="1919" height="959" alt="Screenshot 2026-04-15 001427" src="https://github.com/user-attachments/assets/ec068007-86ee-4fac-b552-0a1306c777bf" />

---

# Overview  

This PR introduces **Redis-based caching for publications APIs** to significantly improve performance and reduce database load.

A centralized caching layer has been implemented to handle:
- Cache reads (GET)
- Cache writes (SET)
- Cache invalidation (on CREATE / UPDATE / DELETE)

Caching is applied at the **department-level aggregation**.

---

# File Changes

## 1. publicationsCache.js (NEW)

### ➤ Added centralized cache utility

- getPublicationsCache(key)  
- setPublicationsCache(key, data)  
- invalidatePublicationsCache(email)  -> utility function to invalidate publications cache
- getPublicationsKey(type) 
- getDepartmentFromEmail(email) -> helper function to identify owner of publication
---

### ➤ Cache Key Strategy

key => publications:${(type || 'all')}
for example,
publications:all
publications:cse  
publications:ece  
and likewise for other departments too

- Stores aggregated publications per department  
- Reduces number of keys  
- Simplifies invalidation  

---

### ➤ TTL Added

EX 21600 (6 hours)

- Prevents stale cache  
- Ensures eventual consistency  

---

### ➤ Logging

Cache HIT → key  
Cache MISS → key  
Cache SET → key  

---

## Publication Related Tables
The following are the relevant tables which should be considered as a trigger when changed to invalidate the cache:
- conference_papers
- textbooks
- journal_papers
- book_chapters

## 2. create/route.js

- Cache invalidation added after:
  - user creation  
  - publication creation

---

## 3. update/route.js

- Cache invalidation added after:
  - user updates  
  - publication updates  

---

## 4. delete/route.js

- Cache invalidation added after:
  - user deletion  
  - publication deletion  

---

## Full Cache Invalidation
When there are changes in user table like faculty's department changed or likewise, publications cache is invalidated to avoid stale data 

---

## Centralized cache layer

All Redis logic regarding publications caching is in:
publicationsCache.js  

---

# Impact

### Performance
- Reduced response time from ~4–5 seconds → near instant (cache hit)

### Database Load
- Fewer repeated DB queries  

<img width="1798" height="594" alt="Screenshot 2026-04-15 002342" src="https://github.com/user-attachments/assets/c2c39008-1370-4088-ad99-3767bbe85486" />
<img width="1789" height="723" alt="Screenshot 2026-04-15 002403" src="https://github.com/user-attachments/assets/4ce3a32d-c431-4450-abc9-8864ba2722ad" />
<img width="1018" height="238" alt="Screenshot 2026-04-15 002507" src="https://github.com/user-attachments/assets/6ab77b3b-0185-4dc4-aac2-2bb63ec79218" />

---